### PR TITLE
replace mul_add in lerp with separate multiply and add

### DIFF
--- a/src/noise/perlin.rs
+++ b/src/noise/perlin.rs
@@ -16,7 +16,7 @@
 //! An implementation of Ken Perlin's [Improved Noise]
 //! (http://mrl.nyu.edu/~perlin/noise/) algorithm.
 
-use std::num::{cast, one, mul_add, zero};
+use std::num::{cast, one, zero};
 use std::rand::{Rng, SeedableRng, StdRng};
 use std::vec;
 
@@ -216,7 +216,7 @@ fn fade<T: Float>(t: T) -> T {
 
 #[inline]
 fn lerp<T: Float>(t: T, a: T, b: T) -> T {
-    mul_add(t, b - a, a)
+    t * (b - a) + a
 }
 
 fn grad<T: Float>(hash: u8, x: T, y: T, z: T) -> T {


### PR DESCRIPTION
Many common CPUs (like the Intel Sandy Bridge in my laptop) don't support FMA
in hardware, so LLVM emulates it in software instead. Replacing the FMA with a
multiply and add sped up my [benchmark](https://github.com/rlane/cubeland/blob/master/src/cubeland/terrain.rs) by 3x on OS X and 30x inside a 32-bit
Linux VM.

This has the downside of losing some precision. If that isn't acceptable then
we could make this a compile-time option.
