### PR TITLE
Function for normalizing the probability distribution of simplex noise

### DIFF
--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -21,7 +21,7 @@ extern crate test;
 
 use noise::Seed;
 use noise::{perlin2, perlin3, perlin4};
-use noise::{open_simplex2, open_simplex3};
+use noise::{open_simplex2, open_simplex3, normalize_simplex};
 use noise::{cell2_range, cell3_range, cell4_range};
 use noise::{cell2_range_inv, cell3_range_inv, cell4_range_inv};
 use noise::{cell2_value, cell3_value, cell4_value};
@@ -58,6 +58,18 @@ fn bench_open_simplex2(bencher: &mut Bencher) {
 fn bench_open_simplex3(bencher: &mut Bencher) {
     let seed = Seed::new(0);
     bencher.iter(|| open_simplex3(black_box(&seed), black_box(&[42.0f32, 37.0, 26.0])));
+}
+
+#[bench]
+fn bench_open_simplex2_normalized(bencher: &mut Bencher) {
+    let seed = Seed::new(0);
+    bencher.iter(|| normalize_simplex(open_simplex2(black_box(&seed), black_box(&[42.0f32, 37.0]))));
+}
+
+#[bench]
+fn bench_open_simplex3_normalized(bencher: &mut Bencher) {
+    let seed = Seed::new(0);
+    bencher.iter(|| normalize_simplex(open_simplex3(black_box(&seed), black_box(&[42.0f32, 37.0, 26.0]))));
 }
 
 #[bench]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ extern crate rand;
 pub use seed::Seed;
 pub use math::{Point2, Point3, Point4};
 pub use perlin::{perlin2, perlin3, perlin4};
-pub use open_simplex::{open_simplex2, open_simplex3};
+pub use open_simplex::{open_simplex2, open_simplex3, normalize_simplex};
 pub use brownian::{Brownian2, Brownian3, Brownian4};
 
 pub use cell::{range_sqr_euclidian2, range_sqr_euclidian3, range_sqr_euclidian4};

--- a/src/open_simplex.rs
+++ b/src/open_simplex.rs
@@ -244,7 +244,7 @@ pub fn open_simplex3<T: Float>(seed: &Seed, point: &::Point3<T>) -> T {
 // These factors are derived by sampling the input function (in this case open_simplex2 and
 // open_siplex3). The output range is then divided into bins (in this case 1000), and the
 // respective bin value is incremented. When doing a high number of samples, this will give us a
-// histogram of the probability distrobution of the function.
+// histogram of the probability distribution of the function.
 //
 // The next step is to perform a Probability integral transform. In our case this is done by doing
 // a cumulative sum on the histogram, from left to right. This would be the integral. This would
@@ -261,7 +261,7 @@ const FACTORS: [f32; 11] = [
     -3.72274565e-03, 2.29025865e+00, 4.93543117e-03];
 
 /// Takes the output of one of the open_simplexn functions as an argument, returns the same value
-/// range as inputted, except transformed to a uniform probabilty distrobution.
+/// range as inputted, except transformed to a uniform probabilty distribution.
 pub fn normalize_simplex(val: f32) -> f32 {
     let mut acc = 0f32;
     acc += FACTORS[0] * val.powi(10);


### PR DESCRIPTION
As is, the probability distribution of simplex noise is not uniform. The probability of getting a value in the center of the distribution is much higher then getting one at the edges. This is fine for most applications, however in some cases it is needed to have a more distribution.

This can be solved by sampling the function to find the probability distribution, integrating the distribution to find the accumulated probability, and finding a cumulative distribution function. The cumulative distribution function can then be applied to samples from the original noise function to find a new value in the normalized distribution.

The code for deriving the numbers in the code is located in this notebook: https://gist.github.com/hansihe/55c7c8c5ffe03ba4c9e2
The green graph is the original probability distribution, the blue is the accumulated probability.
The red graph is the probability distribution after the transform has been applied to the values, the light blue is the accumulated probability of this.

Lastly, here is an image with the transformed and the original noise side by side: http://i.imgur.com/YqfKIBO.png
It does look like the noise is worse, and it probably is for visual purposes, but the chance to get each number from -1 to 1 should be roughly the same, and it is better suited for cases that need uniform probability.
