### PR TITLE
Bump dependency on 'rand'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ authors = ["The Noise-rs Developers."]
 name = "noise"
 
 [dependencies]
-rand = "0.3"
+rand = "0.4"
 image = "0.18"
 
 [[bench]]


### PR DESCRIPTION
rand 0.3 depends on rand 0.4 anyway, so the dependency
graph can only get simpler, if it changes at all.

The only potentially-breaking changes in rand seem
to be centered around 'thread_rng' and 'sample'.
Neither are used directly.