### PR TITLE
Make 'image' an optional dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,11 @@ rust:
   - nightly
 sudo: false
 script:
-  - cargo test
-  - cargo doc
+  - cargo test ${FEATURE_FLAGS}
+  - cargo doc ${FEATURE_FLAGS}
+env:
+  -  FEATURE_FLAGS=""
+  -  FEATURE_FLAGS="--no-default-features"
 matrix:
   allow_failures:
     - rust: nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,121 +14,162 @@ name = "noise"
 
 [dependencies]
 rand = "0.4"
-image = "0.18"
+image = { version = "0.18", optional = true }
+
+[features]
+default = ["image"]
 
 [[bench]]
 name = "benches"
 
 [[example]]
 name = "perlin"
+required-features = ["image"]
 
 [[example]]
 name = "open_simplex"
+required-features = ["image"]
 
 [[example]]
 name = "super_simplex"
+required-features = ["image"]
 
 [[example]]
 name = "value"
+required-features = ["image"]
 
 [[example]]
 name = "constant"
+required-features = ["image"]
 
 [[example]]
 name = "checkerboard"
+required-features = ["image"]
 
 [[example]]
 name = "cylinders"
+required-features = ["image"]
 
 [[example]]
 name = "select"
+required-features = ["image"]
 
 [[example]]
 name = "blend"
+required-features = ["image"]
 
 [[example]]
 name = "abs"
+required-features = ["image"]
 
 [[example]]
 name = "clamp"
+required-features = ["image"]
 
 [[example]]
 name = "curve"
+required-features = ["image"]
 
 [[example]]
 name = "exponent"
+required-features = ["image"]
 
 [[example]]
 name = "invert"
+required-features = ["image"]
 
 [[example]]
 name = "scale_bias"
+required-features = ["image"]
 
 [[example]]
 name = "terrace"
+required-features = ["image"]
 
 [[example]]
 name = "add"
+required-features = ["image"]
 
 [[example]]
 name = "max"
+required-features = ["image"]
 
 [[example]]
 name = "min"
+required-features = ["image"]
 
 [[example]]
 name = "multiply"
+required-features = ["image"]
 
 [[example]]
 name = "power"
+required-features = ["image"]
 
 [[example]]
 name = "fbm"
+required-features = ["image"]
 
 [[example]]
 name = "billow"
+required-features = ["image"]
 
 [[example]]
 name = "basicmulti"
+required-features = ["image"]
 
 [[example]]
 name = "ridgedmulti"
+required-features = ["image"]
 
 [[example]]
 name = "hybridmulti"
+required-features = ["image"]
 
 [[example]]
 name = "cache"
+required-features = ["image"]
 
 [[example]]
 name = "worley"
+required-features = ["image"]
 
 [[example]]
 name = "displace"
+required-features = ["image"]
 
 [[example]]
 name = "rotate_point"
+required-features = ["image"]
 
 [[example]]
 name = "scale_point"
+required-features = ["image"]
 
 [[example]]
 name = "translate_point"
+required-features = ["image"]
 
 [[example]]
 name = "turbulence"
+required-features = ["image"]
 
 [[example]]
 name = "texturewood"
+required-features = ["image"]
 
 [[example]]
 name = "texturejade"
+required-features = ["image"]
 
 [[example]]
 name = "texturegranite"
+required-features = ["image"]
 
 [[example]]
 name = "textureslime"
+required-features = ["image"]
 
 [[example]]
 name = "complexplanet"
+required-features = ["image"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@
 #![cfg_attr(feature = "cargo-clippy", allow(inline_always))]
 #![deny(missing_copy_implementations)]
 
+#[cfg(feature = "image")]
 extern crate image;
 extern crate rand;
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,10 +1,12 @@
 pub use self::color_gradient::*;
+#[cfg(feature = "image")]
 pub use self::image_renderer::*;
 pub use self::noise_image::*;
 pub use self::noise_map::*;
 pub use self::noise_map_builder::*;
 
 mod color_gradient;
+#[cfg(feature = "image")]
 mod image_renderer;
 mod noise_image;
 mod noise_map;

--- a/src/utils/noise_image.rs
+++ b/src/utils/noise_image.rs
@@ -1,5 +1,8 @@
+#[cfg(feature = "image")]
 use image;
+#[cfg(feature = "image")]
 use std;
+#[cfg(feature = "image")]
 use std::path::Path;
 use utils::color_gradient::Color;
 
@@ -90,6 +93,7 @@ impl NoiseImage {
         }
     }
 
+    #[cfg(feature = "image")]
     pub fn write_to_file(&self, filename: &str) {
         // Create the output directory for the images, if it doesn't already exist
         let target_dir = Path::new("example_images/");

--- a/src/utils/noise_map.rs
+++ b/src/utils/noise_map.rs
@@ -1,6 +1,10 @@
+#[cfg(feature = "image")]
 use image;
+#[cfg(feature = "image")]
 use math;
+#[cfg(feature = "image")]
 use std;
+#[cfg(feature = "image")]
 use std::path::*;
 
 const RASTER_MAX_WIDTH: u16 = 32_767;
@@ -82,6 +86,7 @@ impl NoiseMap {
         }
     }
 
+    #[cfg(feature = "image")]
     pub fn write_to_file(&self, filename: &str) {
         // Create the output directory for the images, if it doesn't already exist
         let target_dir = Path::new("example_images/");


### PR DESCRIPTION
This reduces the dependency graph significantly for crates which
use 'noise' just to create noise, and wish to proceed differently.

The second commit adds Travis tests to make sure that both variants work under all rust versions.

Proof that it works: The compilation time is cut in half.