### PR TITLE
[WIP] Refactor noise function construction

### DIFF
--- a/examples/basicmulti.rs
+++ b/examples/basicmulti.rs
@@ -6,7 +6,7 @@ use noise::BasicMulti;
 use noise::utils::*;
 
 fn main() {
-    PlaneMapBuilder::new(&BasicMulti::new())
+    PlaneMapBuilder::new(&BasicMulti::default())
         .build()
         .write_to_file("basicmulti.png");
 }

--- a/examples/texturewood.rs
+++ b/examples/texturewood.rs
@@ -8,12 +8,11 @@ fn main() {
     let base_wood = Cylinders::new().set_frequency(16.0);
 
     // Basic Multifractal noise to use for the wood grain.
-    let wood_grain_noise = BasicMulti::new()
-        .set_seed(0)
-        .set_frequency(48.0)
-        .set_persistence(0.5)
-        .set_lacunarity(2.20703125)
-        .set_octaves(3);
+    let wood_grain_noise = BasicMulti::new(3, FractalParams {
+        frequency: 48.0,
+        persistence: 0.5,
+        lacunarity: 2.20703125,
+    });
 
     // Stretch the perlin noise in the same direction as the center of the log. Should
     // produce a nice wood-grain texture.

--- a/src/noise_fns/generators/fractals/mod.rs
+++ b/src/noise_fns/generators/fractals/mod.rs
@@ -4,6 +4,10 @@ pub use self::fbm::*;
 pub use self::hybridmulti::*;
 pub use self::ridgedmulti::*;
 
+use rand::Rng;
+
+use noise_fns::{seed_rng, default_rng};
+
 mod basicmulti;
 mod billow;
 mod fbm;
@@ -21,6 +25,53 @@ pub trait MultiFractal {
     fn set_lacunarity(self, lacunarity: f64) -> Self;
 
     fn set_persistence(self, persistence: f64) -> Self;
+}
+
+pub trait RandomFractal {
+    /// Generate a new random fractal noise function.
+    ///
+    /// `octaves` is the total number of frequency octaves to generate the noise with. The number of octaves control the
+    /// _amount of detail_ in the noise function. Adding more octaves increases the detail, with the drawback of
+    /// increasing the calculation time.
+    ///
+    /// `params` dictates the relationship between successive octaves; see `FractalParams` for details.
+    fn from_rng<R: Rng + ?Sized>(rng: &mut R, octaves: usize, params: FractalParams) -> Self;
+
+    fn from_seed(seed: u128, octaves: usize, params: FractalParams) -> Self
+    where Self: Sized
+    {
+        Self::from_rng(&mut seed_rng(seed), octaves, params)
+    }
+
+    fn new(octaves: usize, params: FractalParams) -> Self
+    where Self: Sized
+    {
+        Self::from_rng(&mut default_rng(), octaves, params)
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct FractalParams {
+    /// The number of cycles per unit length that the noise function outputs.
+    pub frequency: f64,
+
+    /// A multiplier that determines how quickly the frequency increases for
+    /// each successive octave in the noise function.
+    ///
+    /// The frequency of each successive octave is equal to the product of the
+    /// previous octave's frequency and the lacunarity value.
+    ///
+    /// A lacunarity of 2.0 results in the frequency doubling every octave. For
+    /// almost all cases, 2.0 is a good value to use.
+    pub lacunarity: f64,
+
+    /// A multiplier that determines how quickly the amplitudes diminish for
+    /// each successive octave in the noise function.
+    ///
+    /// The amplitude of each successive octave is equal to the product of the
+    /// previous octave's amplitude and the persistence value. Increasing the
+    /// persistence produces "rougher" noise.
+    pub persistence: f64,
 }
 
 fn build_sources(seed: u32, octaves: usize) -> Vec<Perlin> {

--- a/src/noise_fns/generators/perlin.rs
+++ b/src/noise_fns/generators/perlin.rs
@@ -1,7 +1,8 @@
 use {gradient, math};
 use math::{Point2, Point3, Point4, Vector2, Vector3, Vector4};
-use noise_fns::{NoiseFn, Seedable};
+use noise_fns::{NoiseFn, Seedable, Random, default};
 use permutationtable::PermutationTable;
+use rand::Rng;
 
 /// Noise function that outputs 2/3/4-dimensional Perlin noise.
 #[derive(Clone, Copy, Debug)]
@@ -11,20 +12,13 @@ pub struct Perlin {
 }
 
 impl Perlin {
-    pub const DEFAULT_SEED: u32 = 0;
-
     pub fn new() -> Self {
-        Perlin {
-            seed: Self::DEFAULT_SEED,
-            perm_table: PermutationTable::new(Self::DEFAULT_SEED),
-        }
+        Self::default()
     }
 }
 
 impl Default for Perlin {
-    fn default() -> Self {
-        Self::new()
-    }
+    fn default() -> Self { default() }
 }
 
 impl Seedable for Perlin {
@@ -44,6 +38,12 @@ impl Seedable for Perlin {
 
     fn seed(&self) -> u32 {
         self.seed
+    }
+}
+
+impl Random for Perlin {
+    fn from_rng<R: Rng + ?Sized>(rng: &mut R) -> Self {
+        Self { seed: 0, perm_table: rng.gen() }
     }
 }
 

--- a/src/noise_fns/mod.rs
+++ b/src/noise_fns/mod.rs
@@ -1,3 +1,5 @@
+use rand::{Rng, SeedableRng, XorShiftRng};
+
 pub use self::cache::*;
 pub use self::combiners::*;
 pub use self::generators::*;
@@ -44,3 +46,28 @@ pub trait Seedable {
     /// Getter to retrieve the seed from the function
     fn seed(&self) -> u32;
 }
+
+/// Noise functions that can be randomly generated.
+pub trait Random {
+    fn from_rng<R: Rng + ?Sized>(rng: &mut R) -> Self;
+
+    fn from_seed(seed: u128) -> Self
+        where Self: Sized
+    {
+        Self::from_rng(&mut seed_rng(seed))
+    }
+}
+
+fn default<T: Random>() -> T { T::from_rng(&mut default_rng()) }
+
+const DEFAULT_SEED: u128 = 0x52d80a69a14cb7ee252471a2a8ee0185;
+
+fn seed_rng(seed: u128) -> impl Rng {
+    let mut bytes = [0; 16];
+    for (i, x) in bytes.iter_mut().enumerate() {
+        *x = (seed >> (i * 8)) as u8;
+    }
+    XorShiftRng::from_seed(bytes)
+}
+
+fn default_rng() -> impl Rng { seed_rng(DEFAULT_SEED) }


### PR DESCRIPTION
This is a draft of the API refactoring proposed in #197, with usability tweaks as discussed in IRC. I'd like to get some feedback before proceeding further. Changes were applied to `BasicMulti` and `Perlin` as a hopefully-representative sample, with some redundant code left in place to keep the crate as a whole building until the proposed APIs are more widely implemented.

The most significant impact of this change is that fractal noise functions are constructed with all parameters supplied up front. This is necessary because no meaningful seed value can be saved for RNG-produced noise functions in the general case, and has the incidental benefits of reduced boilerplate and that redundant work is no longer performed when constructing a noise function with a non-default seed or octaves.