### PR TITLE
Feature/revert pass by ref

### DIFF
--- a/examples/complexplanet.rs
+++ b/examples/complexplanet.rs
@@ -263,7 +263,7 @@ fn main() {
 
     // 7: [Base-continent-definition subgroup]: Caches the output value from
     // the clamped-continent module.
-    let baseContinentDef = Cache::new(&baseContinentDef_cl);
+    let baseContinentDef = Cache::new(baseContinentDef_cl);
 
     //    debug::render_noise_module("complexplanet_images/00_5_baseContinentDef.png",
     //                               &baseContinentDef,
@@ -303,7 +303,7 @@ fn main() {
     // output value from the coarse-turbulence module. This turbulence has a
     // higher frequency, but lower power, than the coarse-turbulence module,
     // adding some intermediate detail to it.
-    let continentDef_tu1 = Turbulence::new(&continentDef_tu0)
+    let continentDef_tu1 = Turbulence::new(continentDef_tu0)
         .set_seed(CURRENT_SEED + 11)
         .set_frequency(CONTINENT_FREQUENCY * 47.25)
         .set_power(CONTINENT_FREQUENCY / 433.75)
@@ -319,7 +319,7 @@ fn main() {
     // warps the output value from the intermediate-turbulence module. This
     // turbulence has a higher frequency, but lower power, than the
     // intermediate-turbulence module, adding some fine detail to it.
-    let continentDef_tu2 = Turbulence::new(&continentDef_tu1)
+    let continentDef_tu2 = Turbulence::new(continentDef_tu1)
         .set_seed(CURRENT_SEED + 12)
         .set_frequency(CONTINENT_FREQUENCY * 95.25)
         .set_power(CONTINENT_FREQUENCY / 1019.75)
@@ -354,7 +354,7 @@ fn main() {
     // 5: [Continent-definition group]: Caches the output value from the
     // clamped-continent module. This is the output value for the entire
     // continent-definition group.
-    let continentDef = Cache::new(&continentDef_se);
+    let continentDef = Cache::new(continentDef_se);
 
     //    debug::render_noise_module("complexplanet_images/01_4_continentDef.png",
     //                               &continentDef,
@@ -406,7 +406,7 @@ fn main() {
     // 3: [Terrain-type-definition group]: Caches the output value from the
     // roughness-probability-shift module. This is the output value for the
     // entire terrain-type-definition group.
-    let terrainTypeDef = Cache::new(&terrainTypeDef_te);
+    let terrainTypeDef = Cache::new(terrainTypeDef_te);
 
     // /////////////////////////////////////////////////////////////////////////
     // Function group: mountainous terrain
@@ -480,7 +480,7 @@ fn main() {
     // 7: [Coarse-turbulence module]: This turbulence module warps the output
     // value from the mountain-and-valleys module, adding some coarse detail to
     // it.
-    let mountainBaseDef_tu0 = Turbulence::new(&mountainBaseDef_bl)
+    let mountainBaseDef_tu0 = Turbulence::new(mountainBaseDef_bl)
         .set_seed(CURRENT_SEED + 32)
         .set_frequency(1337.0)
         .set_power(1.0 / 6730.0 * MOUNTAINS_TWIST)
@@ -490,7 +490,7 @@ fn main() {
     // the output value from the coarse-turbulence module. This turbulence has
     // a higher frequency, but lower power, than the coarse-turbulence module,
     // adding some fine detail to it.
-    let mountainBaseDef_tu1 = Turbulence::new(&mountainBaseDef_tu0)
+    let mountainBaseDef_tu1 = Turbulence::new(mountainBaseDef_tu0)
         .set_seed(CURRENT_SEED + 33)
         .set_frequency(21221.0)
         .set_power(1.0 / 120157.0 * MOUNTAINS_TWIST)
@@ -498,7 +498,7 @@ fn main() {
 
     // 9: [Mountain-base-definition subgroup]: Caches the output value from the
     // warped-mountains-and-valleys module.
-    let mountainBaseDef = Cache::new(&mountainBaseDef_tu1);
+    let mountainBaseDef = Cache::new(mountainBaseDef_tu1);
 
     // /////////////////////////////////////////////////////////////////////////
     // Function subgroup: high mountainous terrain (5 noise functions)
@@ -537,7 +537,7 @@ fn main() {
 
     // 4: [Warped-high-mountains module]: This turbulence module warps the
     // output value from the high-mountains module, adding some detail to it.
-    let mountainousHigh_tu = Turbulence::new(&mountainousHigh_ma)
+    let mountainousHigh_tu = Turbulence::new(mountainousHigh_ma)
         .set_seed(CURRENT_SEED + 42)
         .set_frequency(31511.0)
         .set_power(1.0 / 180371.0 * MOUNTAINS_TWIST)
@@ -545,7 +545,7 @@ fn main() {
 
     // 5: [High-mountainous-terrain subgroup]: Caches the output value from the
     // warped-high-mountains module.
-    let mountainousHigh = Cache::new(&mountainousHigh_tu);
+    let mountainousHigh = Cache::new(mountainousHigh_tu);
 
     // /////////////////////////////////////////////////////////////////////////
     // Function subgroup: low mountainous terrain (4 noise functions)
@@ -586,7 +586,7 @@ fn main() {
 
     // 4: [Low-mountainous-terrain subgroup]: Caches the output value from the
     // low-mountainous-terrain module.
-    let mountainousLow = Cache::new(&mountainousLow_mu);
+    let mountainousLow = Cache::new(mountainousLow_mu);
 
     // /////////////////////////////////////////////////////////////////////////
     // Function subgroup: mountainous terrain (7 noise functions)
@@ -657,7 +657,7 @@ fn main() {
     let mountainousTerrain_ex =
         Exponent::new(&mountainousTerrain_sb2).set_exponent(MOUNTAIN_GLACIATION);
 
-    let mountainousTerrain = Cache::new(&mountainousTerrain_ex);
+    let mountainousTerrain = Cache::new(mountainousTerrain_ex);
 
     // ////////////////////////////////////////////////////////////////////////
     // Function group: hilly terrain
@@ -739,7 +739,7 @@ fn main() {
     // 9: [Coarse-turbulence module]: This turbulence module warps the output
     // value from the increased-slope-hilly-terrain module, adding some
     // coarse detail to it.
-    let hillyTerrain_tu0 = Turbulence::new(&hillyTerrain_ex)
+    let hillyTerrain_tu0 = Turbulence::new(hillyTerrain_ex)
         .set_seed(CURRENT_SEED + 62)
         .set_frequency(1531.0)
         .set_power(1.0 / 16921.0 * HILLS_TWIST)
@@ -749,7 +749,7 @@ fn main() {
     // output value from the coarse-turbulence module. This turbulence has a
     // higher frequency, but lower power, than the coarse-turbulence module,
     // adding some fine detail to it.
-    let hillyTerrain_tu1 = Turbulence::new(&hillyTerrain_tu0)
+    let hillyTerrain_tu1 = Turbulence::new(hillyTerrain_tu0)
         .set_seed(CURRENT_SEED + 63)
         .set_frequency(21617.0)
         .set_power(1.0 / 117529.0 * HILLS_TWIST)
@@ -758,7 +758,7 @@ fn main() {
     // 11: [Hilly-terrain group]: Caches the output value from the warped-hilly-
     // terrain module. This is the output value for the entire hilly-terrain
     // group.
-    let hillyTerrain = Cache::new(&hillyTerrain_tu1);
+    let hillyTerrain = Cache::new(hillyTerrain_tu1);
 
     // ////////////////////////////////////////////////////////////////////////
     // Function group: plains terrain
@@ -825,7 +825,7 @@ fn main() {
     // 7: [Plains-terrain group]: Caches the output value from the rescaled-
     // plains-basis module.  This is the output value for the entire plains-
     // terrain group.
-    let plainsTerrain = Cache::new(&plainsTerrain_sb2);
+    let plainsTerrain = Cache::new(plainsTerrain_sb2);
 
     // ////////////////////////////////////////////////////////////////////////
     // Function group: badlands terrain
@@ -880,7 +880,7 @@ fn main() {
 
     // 6: [Badlands-sand subgroup]: Caches the output value from the dunes-with-
     // detail module.
-    let badlandsSand = Cache::new(&badlandsSand_ad);
+    let badlandsSand = Cache::new(badlandsSand_ad);
 
     // ////////////////////////////////////////////////////////////////////////
     // Function subgroup: badlands cliffs (7 noise functions)
@@ -932,7 +932,7 @@ fn main() {
 
     // 5: [Coarse-turbulence module]: This turbulence module warps the output
     // value from the terraced-cliffs module, adding some coarse detail to it.
-    let badlandsCliffs_tu0 = Turbulence::new(&badlandsCliffs_te)
+    let badlandsCliffs_tu0 = Turbulence::new(badlandsCliffs_te)
         .set_seed(CURRENT_SEED + 91)
         .set_frequency(16111.0)
         .set_power(1.0 / 141539.0 * BADLANDS_TWIST)
@@ -942,7 +942,7 @@ fn main() {
     // from the coarse-turbulence module. This turbulence has a higher
     // frequency, but lower power, than the coarse-turbulence module, adding
     // some fine detail to it.
-    let badlandsCliffs_tu1 = Turbulence::new(&badlandsCliffs_tu0)
+    let badlandsCliffs_tu1 = Turbulence::new(badlandsCliffs_tu0)
         .set_seed(CURRENT_SEED + 92)
         .set_frequency(36107.0)
         .set_power(1.0 / 211543.0 * BADLANDS_TWIST)
@@ -950,7 +950,7 @@ fn main() {
 
     // 7: [Badlands-cliffs subgroup]: Caches the output value from the warped-
     // cliffs module.
-    let badlandsCliffs = Cache::new(&badlandsCliffs_tu1);
+    let badlandsCliffs = Cache::new(badlandsCliffs_tu1);
 
     // ////////////////////////////////////////////////////////////////////////
     // Function subgroup: badlands terrain (3 noise functions)
@@ -983,7 +983,7 @@ fn main() {
     // 3: [Badlands-terrain group]: Caches the output value from the dunes-and-
     // cliffs module. This is the output value for the entire badlands-terrain
     // group.
-    let badlandsTerrain = Cache::new(&badlandsTerrain_ma);
+    let badlandsTerrain = Cache::new(badlandsTerrain_ma);
 
     //    debug::render_noise_module("complexplanet_images/12_2_badlandsTerrain.png",
     //                               &badlandsTerrain,
@@ -1055,7 +1055,7 @@ fn main() {
     // 6: [Warped-rivers module]: This turbulence module warps the output value
     //    from the combined-rivers module, which twists the rivers.  The high
     //    roughness produces less-smooth rivers.
-    let riverPositions_tu = Turbulence::new(&riverPositions_mi)
+    let riverPositions_tu = Turbulence::new(riverPositions_mi)
         .set_seed(CURRENT_SEED + 102)
         .set_frequency(9.25)
         .set_power(1.0 / 57.75)
@@ -1064,7 +1064,7 @@ fn main() {
     // 7: [River-positions group]: Caches the output value from the warped-
     //    rivers module.  This is the output value for the entire river-
     //    positions group.
-    let riverPositions = Cache::new(&riverPositions_tu);
+    let riverPositions = Cache::new(riverPositions_tu);
 
     // /////////////////////////////////////////////////////////////////////////
     // Function group: scaled mountainous terrain
@@ -1131,7 +1131,7 @@ fn main() {
     // 6: [Scaled-mountainous-terrain group]: Caches the output value from the
     // peak-height-multiplier module.  This is the output value for the
     // entire scaled-mountainous-terrain group.
-    let scaledMountainousTerrain = Cache::new(&scaledMountainousTerrain_mu);
+    let scaledMountainousTerrain = Cache::new(scaledMountainousTerrain_mu);
 
     // /////////////////////////////////////////////////////////////////////////
     // Function group: scaled hilly terrain
@@ -1197,7 +1197,7 @@ fn main() {
     // 6: [Scaled-hilly-terrain group]: Caches the output value from the
     // hilltop-height-multiplier module. This is the output value for the entire
     // scaled-hilly-terrain group.
-    let scaledHillyTerrain = Cache::new(&scaledHillyTerrain_mu);
+    let scaledHillyTerrain = Cache::new(scaledHillyTerrain_mu);
 
     // /////////////////////////////////////////////////////////////////////////
     // Function group: scaled plains terrain
@@ -1230,7 +1230,7 @@ fn main() {
     // 2: [Scaled-plains-terrain group]: Caches the output value from the
     // scaled-plains-terrain module. This is the output value for the entire
     // scaled-plains-terrain group.
-    let scaledPlainsTerrain = Cache::new(&scaledPlainsTerrain_sb0);
+    let scaledPlainsTerrain = Cache::new(scaledPlainsTerrain_sb0);
 
     // /////////////////////////////////////////////////////////////////////////
     // Function group: scaled badlands terrain
@@ -1263,7 +1263,14 @@ fn main() {
     // 2: [Scaled-badlands-terrain group]: Caches the output value from the
     // scaled-badlands-terrain module. This is the output value for the
     // entire scaled-badlands-terrain group.
-    let scaledBadlandsTerrain = Cache::new(&scaledBadlandsTerrain_sb);
+    let scaledBadlandsTerrain = Cache::new(scaledBadlandsTerrain_sb);
+
+    //    debug::render_noise_module("complexplanet_images/17_0_scaledBadlandsTerrain\
+    //    .png",
+    //                               &scaledBadlandsTerrain,
+    //                               1024,
+    //                               1024,
+    //                               1000);
 
     // /////////////////////////////////////////////////////////////////////////
     // Function group: final planet
@@ -1292,11 +1299,25 @@ fn main() {
         .add_control_point(SHELF_LEVEL)
         .add_control_point(1.0);
 
+    //    debug::render_noise_module("complexplanet_images/18_0_continentalShelf_te\
+    //    .png",
+    //                               &continentalShelf_te,
+    //                               1024,
+    //                               1024,
+    //                               1000);
+
     // 2: [Clamped-sea-bottom module]: This clamping module clamps the output
     // value from the shelf-creator module so that its possible range is from
     // the bottom of the ocean to sea level. This is done because this subgroup
     // is only concerned about the oceans.
     let continentalShelf_cl = Clamp::new(&continentalShelf_te).set_bounds(-0.75, SEA_LEVEL);
+
+    //    debug::render_noise_module("complexplanet_images/18_1_continentalShelf_cl\
+    //    .png",
+    //                               &continentalShelf_cl,
+    //                               1024,
+    //                               1024,
+    //                               1000);
 
     // 3: [Oceanic-trench-basis module]: This ridged-multifractal-noise function
     // generates some coherent noise that will be used to generate the oceanic
@@ -1307,6 +1328,13 @@ fn main() {
         .set_lacunarity(CONTINENT_LACUNARITY)
         .set_octaves(16);
 
+    //    debug::render_noise_module("complexplanet_images/18_2_continentalShelf_rm\
+    //    .png",
+    //                               &continentalShelf_rm,
+    //                               1024,
+    //                               1024,
+    //                               1000);
+
     // 4: [Oceanic-trench module]: This scale/bias module inverts the ridges
     // from the oceanic-trench-basis-module so that the ridges become trenches.
     // This noise function also reduces the depth of the trenches so that their
@@ -1315,13 +1343,20 @@ fn main() {
         .set_scale(-0.125)
         .set_bias(-0.125);
 
+    //    debug::render_noise_module("complexplanet_images/18_3_continentalShelf_sb\
+    //    .png",
+    //                               &continentalShelf_sb,
+    //                               1024,
+    //                               1024,
+    //                               1000);
+
     // 5: [Shelf-and-trenches module]: This addition module adds the oceanic
     // trenches to the clamped-sea-bottom module.
     let continentalShelf_ad = Add::new(&continentalShelf_sb, &continentalShelf_cl);
 
     // 6: [Continental-shelf subgroup]: Caches the output value from the shelf-
     //    and-trenches module.
-    let continentalShelf = Cache::new(&continentalShelf_ad);
+    let continentalShelf = Cache::new(continentalShelf_ad);
 
     //    debug::render_noise_module("complexplanet_images/18_4_continentalShelf.png",
     //                               &continentalShelf,
@@ -1367,7 +1402,7 @@ fn main() {
 
     // 3: [Base-continent-elevation subgroup]: Caches the output value from the
     // base-continent-with-oceans module.
-    let baseContinentElev = Cache::new(&baseContinentElev_se);
+    let baseContinentElev = Cache::new(baseContinentElev_se);
 
     //    debug::render_noise_module("complexplanet_images/19_1_baseContinentElev\
     //    .png",
@@ -1393,7 +1428,7 @@ fn main() {
 
     // 2: [Continents-with-plains subgroup]: Caches the output value from the
     // continents-with-plains module.
-    let continentsWithPlains = Cache::new(&continentsWithPlains_ad);
+    let continentsWithPlains = Cache::new(continentsWithPlains_ad);
 
     //    debug::render_noise_module("complexplanet_images/20_0_continentsWithPlains\
     //    .png",
@@ -1438,7 +1473,7 @@ fn main() {
 
     // 3: [Continents-with-hills subgroup]: Caches the output value from the
     // select-high-elevations module.
-    let continentsWithHills = Cache::new(&continentsWithHills_se);
+    let continentsWithHills = Cache::new(continentsWithHills_se);
 
     //    debug::render_noise_module("complexplanet_images/21_1_continentsWithHills\
     //    .png",
@@ -1515,7 +1550,7 @@ fn main() {
 
     // 5: [Continents-with-mountains subgroup]: Caches the output value from the
     // select-high-elevations module.
-    let continentsWithMountains = Cache::new(&continentsWithMountains_se);
+    let continentsWithMountains = Cache::new(continentsWithMountains_se);
 
     //    debug::render_noise_module("complexplanet_images/22_3_continentsWithMountains.png",
     //                               &continentsWithMountains,
@@ -1593,7 +1628,7 @@ fn main() {
 
     // 5: [Continents-with-badlands subgroup]: Caches the output value from the
     //    apply-badlands module.
-    let continentsWithBadlands = Cache::new(&continentsWithBadlands_ma);
+    let continentsWithBadlands = Cache::new(continentsWithBadlands_ma);
 
     //    debug::render_noise_module("complexplanet_images/23_3_continentsWithBadlands.png",
     //                               &continentsWithBadlands,
@@ -1653,7 +1688,7 @@ fn main() {
 
     // 4: [Continents-with-rivers subgroup]: Caches the output value from the
     // blended-rivers-to-continents module.
-    let continentsWithRivers = Cache::new(&continentsWithRivers_se);
+    let continentsWithRivers = Cache::new(continentsWithRivers_se);
 
     // /////////////////////////////////////////////////////////////////////////
     // Function subgroup: unscaled final planet (1 noise function)
@@ -1664,7 +1699,7 @@ fn main() {
 
     // 1: [Unscaled-final-planet subgroup]: Caches the output value from the
     //    continent-with-rivers subgroup.
-    let unscaledFinalPlanet = Cache::new(&continentsWithRivers);
+    let unscaledFinalPlanet = Cache::new(continentsWithRivers);
 
     //    debug::render_noise_module3(
     //        "complexplanet_images/30_0_unscaledFinalPlanet\

--- a/examples/displace.rs
+++ b/examples/displace.rs
@@ -8,7 +8,7 @@ fn main() {
     let constant = Constant::new(0.0);
     let cylinders = Cylinders::new();
     let perlin = Perlin::new();
-    let displace = Displace::new(&cylinders, &cboard, &perlin, &constant, &constant);
+    let displace = Displace::new(cylinders, cboard, perlin, constant, constant);
 
     PlaneMapBuilder::new(&displace)
         .build()

--- a/examples/rotate_point.rs
+++ b/examples/rotate_point.rs
@@ -5,7 +5,7 @@ use noise::utils::*;
 
 fn main() {
     let cylinders = Cylinders::new();
-    let rotate_point = RotatePoint::new(&cylinders).set_x_angle(60.0);
+    let rotate_point = RotatePoint::new(cylinders).set_x_angle(60.0);
 
     PlaneMapBuilder::new(&rotate_point)
         .build()

--- a/examples/scale_point.rs
+++ b/examples/scale_point.rs
@@ -5,7 +5,7 @@ use noise::utils::*;
 
 fn main() {
     let cboard = Checkerboard::new();
-    let scale_point = ScalePoint::new(&cboard).set_all_scales(1.0, 2.0, 3.0, 1.0);
+    let scale_point = ScalePoint::new(cboard).set_all_scales(1.0, 2.0, 3.0, 1.0);
 
     PlaneMapBuilder::new(&scale_point)
         .set_size(500, 500)

--- a/examples/texturegranite.rs
+++ b/examples/texturegranite.rs
@@ -28,7 +28,7 @@ fn main() {
     let combined_granite = Add::new(&primary_granite, &scaled_grains);
 
     // Finally, perturb the granite texture to add realism.
-    let final_granite = Turbulence::new(&combined_granite)
+    let final_granite = Turbulence::new(combined_granite)
         .set_seed(2)
         .set_frequency(4.0)
         .set_power(1.0 / 8.0)

--- a/examples/texturejade.rs
+++ b/examples/texturejade.rs
@@ -20,10 +20,10 @@ fn main() {
     // aligned with any axis. This produces more variation in the secondary
     // jade texture since the texture is parallel to the y-axis.
     let rotated_base_secondary_jade =
-        RotatePoint::new(&base_secondary_jade).set_angles(90.0, 25.0, 5.0, 0.0);
+        RotatePoint::new(base_secondary_jade).set_angles(90.0, 25.0, 5.0, 0.0);
 
     // Slightly perturb the secondary jade texture for more realism.
-    let perturbed_base_secondary_jade = Turbulence::new(&rotated_base_secondary_jade)
+    let perturbed_base_secondary_jade = Turbulence::new(rotated_base_secondary_jade)
         .set_seed(1)
         .set_frequency(4.0)
         .set_power(1.0 / 4.0)
@@ -42,7 +42,7 @@ fn main() {
 
     // Finally, perturb the combined jade texture to produce the final jade
     // texture. A low roughness produces nice veins.
-    let final_jade = Turbulence::new(&combined_jade)
+    let final_jade = Turbulence::new(combined_jade)
         .set_seed(2)
         .set_frequency(4.0)
         .set_power(1.0 / 16.0)

--- a/examples/textureslime.rs
+++ b/examples/textureslime.rs
@@ -43,7 +43,7 @@ fn main() {
         .set_falloff(0.5);
 
     // Finally, perturb the slime texture to add realism.
-    let final_slime = Turbulence::new(&slime_chooser)
+    let final_slime = Turbulence::new(slime_chooser)
         .set_seed(3)
         .set_frequency(8.0)
         .set_power(1.0 / 32.0)

--- a/examples/texturewood.rs
+++ b/examples/texturewood.rs
@@ -17,7 +17,7 @@ fn main() {
 
     // Stretch the perlin noise in the same direction as the center of the log. Should
     // produce a nice wood-grain texture.
-    let scaled_base_wood_grain = ScalePoint::new(&wood_grain_noise).set_y_scale(0.25);
+    let scaled_base_wood_grain = ScalePoint::new(wood_grain_noise).set_y_scale(0.25);
 
     // Scale the wood-grain values so that they can be added to the base wood texture.
     let wood_grain = ScaleBias::new(&scaled_base_wood_grain)
@@ -28,20 +28,20 @@ fn main() {
     let combined_wood = Add::new(&base_wood, &wood_grain);
 
     // Slightly perturb the wood to create a more realistic texture.
-    let perturbed_wood = Turbulence::new(&combined_wood)
+    let perturbed_wood = Turbulence::new(combined_wood)
         .set_seed(1)
         .set_frequency(4.0)
         .set_power(1.0 / 256.0)
         .set_roughness(4);
 
     // Cut the wood texture a small distance from the center of the log.
-    let translated_wood = TranslatePoint::new(&perturbed_wood).set_y_translation(1.48);
+    let translated_wood = TranslatePoint::new(perturbed_wood).set_y_translation(1.48);
 
     // Set the cut on a angle to produce a more interesting texture.
-    let rotated_wood = RotatePoint::new(&translated_wood).set_angles(84.0, 0.0, 0.0, 0.0);
+    let rotated_wood = RotatePoint::new(translated_wood).set_angles(84.0, 0.0, 0.0, 0.0);
 
     // Finally, perturb the wood texture again to produce the final texture.
-    let final_wood = Turbulence::new(&rotated_wood)
+    let final_wood = Turbulence::new(rotated_wood)
         .set_seed(2)
         .set_frequency(2.0)
         .set_power(1.0 / 64.0)

--- a/examples/translate_point.rs
+++ b/examples/translate_point.rs
@@ -5,7 +5,7 @@ use noise::utils::*;
 
 fn main() {
     let cboard = Checkerboard::new();
-    let translate_point = TranslatePoint::new(&cboard).set_all_translations(0.5, 0.5, 0.0, 0.0);
+    let translate_point = TranslatePoint::new(cboard).set_all_translations(0.5, 0.5, 0.0, 0.0);
 
     PlaneMapBuilder::new(&translate_point)
         .build()

--- a/src/noise_fns/cache.rs
+++ b/src/noise_fns/cache.rs
@@ -16,17 +16,17 @@ use std::cell::{Cell, RefCell};
 /// function will redundantly calculate the same output value once for each
 /// noise function in which it is included.
 #[derive(Clone, Debug)]
-pub struct Cache<'a, Source: 'a> {
+pub struct Cache<Source> {
     /// Outputs the value to be cached.
-    pub source: &'a Source,
+    pub source: Source,
 
     value: Cell<Option<f64>>,
 
     point: RefCell<Vec<f64>>,
 }
 
-impl<'a, Source> Cache<'a, Source> {
-    pub fn new(source: &'a Source) -> Self {
+impl<Source> Cache<Source> {
+    pub fn new(source: Source) -> Self {
         Cache {
             source,
             value: Cell::new(None),
@@ -35,7 +35,7 @@ impl<'a, Source> Cache<'a, Source> {
     }
 }
 
-impl<'a, Source> NoiseFn<Point2<f64>> for Cache<'a, Source>
+impl<Source> NoiseFn<Point2<f64>> for Cache<Source>
 where
     Source: NoiseFn<Point2<f64>>,
 {
@@ -56,7 +56,7 @@ where
     }
 }
 
-impl<'a, Source> NoiseFn<Point3<f64>> for Cache<'a, Source>
+impl<Source> NoiseFn<Point3<f64>> for Cache<Source>
 where
     Source: NoiseFn<Point3<f64>>,
 {
@@ -77,7 +77,7 @@ where
     }
 }
 
-impl<'a, Source> NoiseFn<Point4<f64>> for Cache<'a, Source>
+impl<Source> NoiseFn<Point4<f64>> for Cache<Source>
 where
     Source: NoiseFn<Point4<f64>>,
 {

--- a/src/noise_fns/transformers/displace.rs
+++ b/src/noise_fns/transformers/displace.rs
@@ -3,36 +3,36 @@ use noise_fns::NoiseFn;
 
 /// Noise function that uses multiple source functions to displace each coordinate
 /// of the input value before returning the output value from the `source` function.
-pub struct Displace<'a, Source: 'a, XDisplace: 'a, YDisplace: 'a, ZDisplace: 'a, UDisplace: 'a> {
+pub struct Displace<Source, XDisplace, YDisplace, ZDisplace, UDisplace> {
     /// Source function that outputs a value
-    pub source: &'a Source,
+    pub source: Source,
 
     /// Displacement function that displaces the _x_ coordinate of the input
     /// value.
-    pub x_displace: &'a XDisplace,
+    pub x_displace: XDisplace,
 
     /// Displacement function that displaces the _y_ coordinate of the input
     /// value.
-    pub y_displace: &'a YDisplace,
+    pub y_displace: YDisplace,
 
     /// Displacement function that displaces the _z_ coordinate of the input
     /// value. Only needed for 3d or higher noise.
-    pub z_displace: &'a ZDisplace,
+    pub z_displace: ZDisplace,
 
     /// Displacement function that displaces the _u_ coordinate of the input
     /// value. Only needed for 4d or higher noise.
-    pub u_displace: &'a UDisplace,
+    pub u_displace: UDisplace,
 }
 
-impl<'a, Source, XDisplace, YDisplace, ZDisplace, UDisplace>
-    Displace<'a, Source, XDisplace, YDisplace, ZDisplace, UDisplace>
+impl<Source, XDisplace, YDisplace, ZDisplace, UDisplace>
+    Displace<Source, XDisplace, YDisplace, ZDisplace, UDisplace>
 {
     pub fn new(
-        source: &'a Source,
-        x_displace: &'a XDisplace,
-        y_displace: &'a YDisplace,
-        z_displace: &'a ZDisplace,
-        u_displace: &'a UDisplace,
+        source: Source,
+        x_displace: XDisplace,
+        y_displace: YDisplace,
+        z_displace: ZDisplace,
+        u_displace: UDisplace,
     ) -> Self {
         Displace {
             source,
@@ -45,8 +45,8 @@ impl<'a, Source, XDisplace, YDisplace, ZDisplace, UDisplace>
 }
 
 #[cfg_attr(rustfmt, rustfmt_skip)]
-impl<'a, Source, XDisplace, YDisplace, ZDisplace, UDisplace> NoiseFn<Point2<f64>>
-    for Displace<'a, Source, XDisplace, YDisplace, ZDisplace, UDisplace>
+impl<Source, XDisplace, YDisplace, ZDisplace, UDisplace> NoiseFn<Point2<f64>>
+    for Displace<Source, XDisplace, YDisplace, ZDisplace, UDisplace>
     where Source: NoiseFn<Point2<f64>>,
           XDisplace: NoiseFn<Point2<f64>>,
           YDisplace: NoiseFn<Point2<f64>>,
@@ -65,8 +65,8 @@ impl<'a, Source, XDisplace, YDisplace, ZDisplace, UDisplace> NoiseFn<Point2<f64>
 }
 
 #[cfg_attr(rustfmt, rustfmt_skip)]
-impl<'a, Source, XDisplace, YDisplace, ZDisplace, UDisplace> NoiseFn<Point3<f64>>
-    for Displace<'a, Source, XDisplace, YDisplace, ZDisplace, UDisplace>
+impl<Source, XDisplace, YDisplace, ZDisplace, UDisplace> NoiseFn<Point3<f64>>
+    for Displace<Source, XDisplace, YDisplace, ZDisplace, UDisplace>
     where Source: NoiseFn<Point3<f64>>,
           XDisplace: NoiseFn<Point3<f64>>,
           YDisplace: NoiseFn<Point3<f64>>,
@@ -88,8 +88,8 @@ impl<'a, Source, XDisplace, YDisplace, ZDisplace, UDisplace> NoiseFn<Point3<f64>
 }
 
 #[cfg_attr(rustfmt, rustfmt_skip)]
-impl<'a, Source, XDisplace, YDisplace, ZDisplace, UDisplace> NoiseFn<Point4<f64>>
-    for Displace<'a, Source, XDisplace, YDisplace, ZDisplace, UDisplace>
+impl<Source, XDisplace, YDisplace, ZDisplace, UDisplace> NoiseFn<Point4<f64>>
+    for Displace<Source, XDisplace, YDisplace, ZDisplace, UDisplace>
     where Source: NoiseFn<Point4<f64>>,
           XDisplace: NoiseFn<Point4<f64>>,
           YDisplace: NoiseFn<Point4<f64>>,

--- a/src/noise_fns/transformers/rotate_point.rs
+++ b/src/noise_fns/transformers/rotate_point.rs
@@ -9,9 +9,9 @@ use noise_fns::NoiseFn;
 ///
 /// The coordinate system of the input value is assumed to be "right-handed"
 /// (_x_ increases to the right, _y_ increases upward, and _z_ increases inward).
-pub struct RotatePoint<'a, Source: 'a> {
+pub struct RotatePoint<Source> {
     /// Source function that outputs a value
-    pub source: &'a Source,
+    pub source: Source,
 
     /// _x_ rotation angle applied to the input value, in degrees. The
     /// default angle is set to 0.0 degrees.
@@ -30,8 +30,8 @@ pub struct RotatePoint<'a, Source: 'a> {
     pub u_angle: f64,
 }
 
-impl<'a, Source> RotatePoint<'a, Source> {
-    pub fn new(source: &'a Source) -> Self {
+impl<Source> RotatePoint<Source> {
+    pub fn new(source: Source) -> Self {
         RotatePoint {
             source,
             x_angle: 0.0,
@@ -78,7 +78,7 @@ impl<'a, Source> RotatePoint<'a, Source> {
     }
 }
 
-impl<'a, Source> NoiseFn<Point2<f64>> for RotatePoint<'a, Source>
+impl<Source> NoiseFn<Point2<f64>> for RotatePoint<Source>
 where
     Source: NoiseFn<Point2<f64>>,
 {
@@ -98,7 +98,7 @@ where
     }
 }
 
-impl<'a, Source> NoiseFn<Point3<f64>> for RotatePoint<'a, Source>
+impl<Source> NoiseFn<Point3<f64>> for RotatePoint<Source>
 where
     Source: NoiseFn<Point3<f64>>,
 {
@@ -132,7 +132,7 @@ where
     }
 }
 
-impl<'a, Source> NoiseFn<Point4<f64>> for RotatePoint<'a, Source>
+impl<Source> NoiseFn<Point4<f64>> for RotatePoint<Source>
 where
     Source: NoiseFn<Point4<f64>>,
 {

--- a/src/noise_fns/transformers/scale_point.rs
+++ b/src/noise_fns/transformers/scale_point.rs
@@ -6,9 +6,9 @@ use noise_fns::NoiseFn;
 ///
 /// The get() method multiplies the coordinates of the input value with a
 /// scaling factor before returning the output value from the source function.
-pub struct ScalePoint<'a, Source: 'a> {
+pub struct ScalePoint<Source> {
     /// Source function that outputs a value
-    pub source: &'a Source,
+    pub source: Source,
 
     /// Scaling factor applied to the _x_ coordinate of the input value. The
     /// default scaling factor is set to 1.0.
@@ -27,8 +27,8 @@ pub struct ScalePoint<'a, Source: 'a> {
     pub u_scale: f64,
 }
 
-impl<'a, Source> ScalePoint<'a, Source> {
-    pub fn new(source: &'a Source) -> Self {
+impl<Source> ScalePoint<Source> {
+    pub fn new(source: Source) -> Self {
         ScalePoint {
             source,
             x_scale: 1.0,
@@ -86,7 +86,7 @@ impl<'a, Source> ScalePoint<'a, Source> {
     }
 }
 
-impl<'a, Source> NoiseFn<Point2<f64>> for ScalePoint<'a, Source>
+impl<Source> NoiseFn<Point2<f64>> for ScalePoint<Source>
 where
     Source: NoiseFn<Point2<f64>>,
 {
@@ -96,7 +96,7 @@ where
     }
 }
 
-impl<'a, Source> NoiseFn<Point3<f64>> for ScalePoint<'a, Source>
+impl<Source> NoiseFn<Point3<f64>> for ScalePoint<Source>
 where
     Source: NoiseFn<Point3<f64>>,
 {
@@ -109,7 +109,7 @@ where
     }
 }
 
-impl<'a, Source> NoiseFn<Point4<f64>> for ScalePoint<'a, Source>
+impl<Source> NoiseFn<Point4<f64>> for ScalePoint<Source>
 where
     Source: NoiseFn<Point4<f64>>,
 {

--- a/src/noise_fns/transformers/scale_point.rs
+++ b/src/noise_fns/transformers/scale_point.rs
@@ -122,3 +122,45 @@ where
         ])
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use super::super::super::Perlin;
+
+    #[test]
+    fn test_pass_by_ref() {
+        let source = Perlin::new();
+        let transformed_by_ref = ScalePoint::new(&source).
+            set_x_scale(0.8).
+            set_y_scale(0.1).
+            set_z_scale(0.4).
+            set_u_scale(0.2);
+        let mut zero_count = 0;
+
+        for x in 0..10 {
+            for y in 0..10 {
+                for z in 0..10 {
+                    for u in 0..10 {
+                        let point: [f64; 4] = [
+                            (x as f64) / 10.0,
+                            (y as f64) / 10.0,
+                            (z as f64) / 10.0,
+                            (u as f64) / 10.0
+                        ];
+                        let source_value = source.get(point);
+                        let transform_value = transformed_by_ref.get(point);
+
+                        if source_value != 0.0 {
+                            assert_ne!(source_value, transform_value);
+                        } else {
+                            zero_count += 1;
+                        }
+                    }
+                }
+            }
+        }
+
+        assert!(zero_count < 10 * 10 * 10 * 10);
+    }
+}

--- a/src/noise_fns/transformers/translate_point.rs
+++ b/src/noise_fns/transformers/translate_point.rs
@@ -6,9 +6,9 @@ use noise_fns::NoiseFn;
 ///
 /// The get() method moves the coordinates of the input value by a translation
 /// amount before returning the output value from the source function.
-pub struct TranslatePoint<'a, Source: 'a> {
+pub struct TranslatePoint<Source> {
     /// Source function that outputs a value
-    pub source: &'a Source,
+    pub source: Source,
 
     /// Translation amount applied to the _x_ coordinate of the input value.
     /// The default translation amount is set to 0.0.
@@ -27,8 +27,8 @@ pub struct TranslatePoint<'a, Source: 'a> {
     pub u_translation: f64,
 }
 
-impl<'a, Source> TranslatePoint<'a, Source> {
-    pub fn new(source: &'a Source) -> Self {
+impl<Source> TranslatePoint<Source> {
+    pub fn new(source: Source) -> Self {
         TranslatePoint {
             source,
             x_translation: 0.0,
@@ -104,7 +104,7 @@ impl<'a, Source> TranslatePoint<'a, Source> {
     }
 }
 
-impl<'a, Source> NoiseFn<Point2<f64>> for TranslatePoint<'a, Source>
+impl<Source> NoiseFn<Point2<f64>> for TranslatePoint<Source>
 where
     Source: NoiseFn<Point2<f64>>,
 {
@@ -114,7 +114,7 @@ where
     }
 }
 
-impl<'a, Source> NoiseFn<Point3<f64>> for TranslatePoint<'a, Source>
+impl<Source> NoiseFn<Point3<f64>> for TranslatePoint<Source>
 where
     Source: NoiseFn<Point3<f64>>,
 {
@@ -127,7 +127,7 @@ where
     }
 }
 
-impl<'a, Source> NoiseFn<Point4<f64>> for TranslatePoint<'a, Source>
+impl<Source> NoiseFn<Point4<f64>> for TranslatePoint<Source>
 where
     Source: NoiseFn<Point4<f64>>,
 {

--- a/src/noise_fns/transformers/turbulence.rs
+++ b/src/noise_fns/transformers/turbulence.rs
@@ -10,9 +10,9 @@ use noise_fns::{Fbm, MultiFractal, NoiseFn, Seedable};
 /// turbulence, an application can modify its frequency, its power, and its
 /// roughness.
 #[derive(Clone, Debug)]
-pub struct Turbulence<'a, Source: 'a> {
+pub struct Turbulence<Source> {
     /// Source function that outputs a value.
-    pub source: &'a Source,
+    pub source: Source,
 
     /// Frequency value for the Turbulence function.
     pub frequency: f64,
@@ -31,13 +31,13 @@ pub struct Turbulence<'a, Source: 'a> {
     u_distort_function: Fbm,
 }
 
-impl<'a, Source> Turbulence<'a, Source> {
+impl<Source> Turbulence<Source> {
     pub const DEFAULT_SEED: u32 = 0;
     pub const DEFAULT_FREQUENCY: f64 = 1.0;
     pub const DEFAULT_POWER: f64 = 1.0;
     pub const DEFAULT_ROUGHNESS: usize = 3;
 
-    pub fn new(source: &'a Source) -> Self {
+    pub fn new(source: Source) -> Self {
         Turbulence {
             source,
             seed: Self::DEFAULT_SEED,
@@ -90,7 +90,7 @@ impl<'a, Source> Turbulence<'a, Source> {
     }
 }
 
-impl<'a, Source> Seedable for Turbulence<'a, Source> {
+impl<Source> Seedable for Turbulence<Source> {
     fn set_seed(self, seed: u32) -> Self {
         Turbulence {
             seed,
@@ -107,7 +107,7 @@ impl<'a, Source> Seedable for Turbulence<'a, Source> {
     }
 }
 
-impl<'a, Source> NoiseFn<Point2<f64>> for Turbulence<'a, Source>
+impl<Source> NoiseFn<Point2<f64>> for Turbulence<Source>
 where
     Source: NoiseFn<Point2<f64>>,
 {
@@ -128,7 +128,7 @@ where
     }
 }
 
-impl<'a, Source> NoiseFn<Point3<f64>> for Turbulence<'a, Source>
+impl<Source> NoiseFn<Point3<f64>> for Turbulence<Source>
 where
     Source: NoiseFn<Point3<f64>>,
 {
@@ -156,7 +156,7 @@ where
     }
 }
 
-impl<'a, Source> NoiseFn<Point4<f64>> for Turbulence<'a, Source>
+impl<Source> NoiseFn<Point4<f64>> for Turbulence<Source>
 where
     Source: NoiseFn<Point4<f64>>,
 {


### PR DESCRIPTION
This PR reverts the change that makes noise transformers "pass by ref". Creating this restriction takes away a lot of flexibility of the library. For instance, we can no longer pass transformed noise between threads, make copies of transformed noise, or pass in other sources aside from a reference.

I added a test to show that it is still quite possible to construct a transformer by ref without imposing the lifetime parameter and reference in the type system.

Let me know if I missed the reason for doing this in the first place, I know for my use case I do not want to use references as the source