### PR TITLE
Implement Index and IndexMut for NoiseMap and NoiseImage

### DIFF
--- a/src/utils/image_renderer.rs
+++ b/src/utils/image_renderer.rs
@@ -125,7 +125,7 @@ impl ImageRenderer {
 
         for y in 0..height {
             for x in 0..width {
-                let point = noise_map.get_value(x, y);
+                let point = noise_map[(x, y)];
 
                 let source_color = self.gradient.get_color(point);
 
@@ -172,10 +172,10 @@ impl ImageRenderer {
                     }
 
                     let pc = point;
-                    let pl = noise_map.get_value((x as isize + x_left_offset) as usize, y);
-                    let pr = noise_map.get_value((x as isize + x_right_offset) as usize, y);
-                    let pd = noise_map.get_value(x, (y as isize + y_down_offset) as usize);
-                    let pu = noise_map.get_value(x, (y as isize + y_up_offset) as usize);
+                    let pl = noise_map[((x as isize + x_left_offset) as usize, y)];
+                    let pr = noise_map[((x as isize + x_right_offset) as usize, y)];
+                    let pd = noise_map[(x, (y as isize + y_down_offset) as usize)];
+                    let pu = noise_map[(x, (y as isize + y_up_offset) as usize)];
 
                     light_intensity = self.light_source.calc_light_intensity(pc, pl, pr, pd, pu);
                     light_intensity *= self.light_source.brightness;
@@ -185,7 +185,7 @@ impl ImageRenderer {
 
                 let destination_color = self.calc_destination_color(source_color, light_intensity);
 
-                destination_image.set_value(x, y, destination_color);
+                destination_image[(x, y)] = destination_color;
             }
         }
 
@@ -237,7 +237,7 @@ impl ImageRenderer {
 
         for y in 0..height {
             for x in 0..width {
-                let point = noise_map.get_value(x, y);
+                let point = noise_map[(x, y)];
                 let source_color = self.gradient.get_color(point);
 
                 let mut light_intensity;
@@ -283,10 +283,10 @@ impl ImageRenderer {
                     }
 
                     let pc = point;
-                    let pl = noise_map.get_value((x as isize + x_left_offset) as usize, y);
-                    let pr = noise_map.get_value((x as isize + x_right_offset) as usize, y);
-                    let pd = noise_map.get_value(x, (y as isize + y_down_offset) as usize);
-                    let pu = noise_map.get_value(x, (y as isize + y_up_offset) as usize);
+                    let pl = noise_map[((x as isize + x_left_offset) as usize, y)];
+                    let pr = noise_map[((x as isize + x_right_offset) as usize, y)];
+                    let pd = noise_map[(x, (y as isize + y_down_offset) as usize)];
+                    let pu = noise_map[(x, (y as isize + y_up_offset) as usize)];
 
                     light_intensity = self.light_source.calc_light_intensity(pc, pl, pr, pd, pu);
                     light_intensity *= self.light_source.brightness;
@@ -294,7 +294,7 @@ impl ImageRenderer {
                     light_intensity = 1.0;
                 }
 
-                let background_color = background.get_value(x, y);
+                let background_color = background[(x, y)];
 
                 let destination_color = self.calc_destination_color_with_background(
                     source_color,
@@ -302,7 +302,7 @@ impl ImageRenderer {
                     light_intensity,
                 );
 
-                destination_image.set_value(x, y, destination_color);
+                destination_image[(x, y)] = destination_color;
             }
         }
 

--- a/src/utils/noise_map.rs
+++ b/src/utils/noise_map.rs
@@ -1,7 +1,9 @@
+use std::ops::{Index, IndexMut};
+use std::slice::{Iter, IterMut};
+use std::vec::IntoIter;
+
 #[cfg(feature = "image")]
 use std::{self, path::Path};
-
-use std::ops::{Index, IndexMut};
 
 const RASTER_MAX_WIDTH: u16 = 32_767;
 const RASTER_MAX_HEIGHT: u16 = 32_767;
@@ -17,12 +19,12 @@ impl NoiseMap {
         Self::initialize().set_size(width, height)
     }
 
-    pub fn data(&self) -> &[f64] {
-        &self.map
+    pub fn iter(&self) -> Iter<'_, f64> {
+        self.map.iter()
     }
 
-    pub fn data_mut(&mut self) -> &mut [f64] {
-        &mut self.map
+    pub fn iter_mut(&mut self) -> IterMut<'_, f64> {
+        self.map.iter_mut()
     }
 
     pub fn set_size(self, width: usize, height: usize) -> Self {
@@ -161,5 +163,35 @@ impl IndexMut<(usize, usize)> for NoiseMap {
                 x, y, width, height
             )
         }
+    }
+}
+
+impl IntoIterator for NoiseMap {
+    type Item = f64;
+
+    type IntoIter = IntoIter<f64>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.map.into_iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a NoiseMap {
+    type Item = &'a f64;
+
+    type IntoIter = Iter<'a, f64>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a mut NoiseMap {
+    type Item = &'a mut f64;
+
+    type IntoIter = IterMut<'a, f64>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter_mut()
     }
 }

--- a/src/utils/noise_map.rs
+++ b/src/utils/noise_map.rs
@@ -141,12 +141,27 @@ impl Index<(usize, usize)> for NoiseMap {
     type Output = f64;
 
     fn index(&self, (x, y): (usize, usize)) -> &Self::Output {
-        &self.map[x + y * self.size.0]
+        let (width, height) = self.size;
+        if x < width && y < height {
+            // SAFETY: We just checked the index on the line above. This is just to avoid another bounds check.
+            unsafe { self.map.get_unchecked(x + y * self.size.0) }
+        } else {
+            &self.border_value
+        }
     }
 }
 
 impl IndexMut<(usize, usize)> for NoiseMap {
     fn index_mut(&mut self, (x, y): (usize, usize)) -> &mut Self::Output {
-        &mut self.map[x + y * self.size.0]
+        let (width, height) = self.size;
+        if x < width && y < height {
+            // SAFETY: We just checked the index on the line above. This is just to avoid another bounds check.
+            unsafe { self.map.get_unchecked_mut(x + y * self.size.0) }
+        } else {
+            panic!(
+                "index ({}, {}) out of bounds for NoiseMap of size ({}, {})",
+                x, y, width, height
+            )
+        }
     }
 }

--- a/src/utils/noise_map.rs
+++ b/src/utils/noise_map.rs
@@ -1,6 +1,8 @@
 #[cfg(feature = "image")]
 use std::{self, path::Path};
 
+use std::ops::{Index, IndexMut};
+
 const RASTER_MAX_WIDTH: u16 = 32_767;
 const RASTER_MAX_HEIGHT: u16 = 32_767;
 
@@ -13,6 +15,14 @@ pub struct NoiseMap {
 impl NoiseMap {
     pub fn new(width: usize, height: usize) -> Self {
         Self::initialize().set_size(width, height)
+    }
+
+    pub fn data(&self) -> &[f64] {
+        &self.map
+    }
+
+    pub fn data_mut(&mut self) -> &mut [f64] {
+        &mut self.map
     }
 
     pub fn set_size(self, width: usize, height: usize) -> Self {
@@ -124,5 +134,19 @@ impl NoiseMap {
 impl Default for NoiseMap {
     fn default() -> Self {
         Self::initialize()
+    }
+}
+
+impl Index<(usize, usize)> for NoiseMap {
+    type Output = f64;
+
+    fn index(&self, (x, y): (usize, usize)) -> &Self::Output {
+        &self.map[x + y * self.size.0]
+    }
+}
+
+impl IndexMut<(usize, usize)> for NoiseMap {
+    fn index_mut(&mut self, (x, y): (usize, usize)) -> &mut Self::Output {
+        &mut self.map[x + y * self.size.0]
     }
 }

--- a/src/utils/noise_map.rs
+++ b/src/utils/noise_map.rs
@@ -143,8 +143,7 @@ impl Index<(usize, usize)> for NoiseMap {
     fn index(&self, (x, y): (usize, usize)) -> &Self::Output {
         let (width, height) = self.size;
         if x < width && y < height {
-            // SAFETY: We just checked the index on the line above. This is just to avoid another bounds check.
-            unsafe { self.map.get_unchecked(x + y * self.size.0) }
+            &self.map[x + y * width]
         } else {
             &self.border_value
         }
@@ -155,8 +154,7 @@ impl IndexMut<(usize, usize)> for NoiseMap {
     fn index_mut(&mut self, (x, y): (usize, usize)) -> &mut Self::Output {
         let (width, height) = self.size;
         if x < width && y < height {
-            // SAFETY: We just checked the index on the line above. This is just to avoid another bounds check.
-            unsafe { self.map.get_unchecked_mut(x + y * self.size.0) }
+            &mut self.map[x + y * width]
         } else {
             panic!(
                 "index ({}, {}) out of bounds for NoiseMap of size ({}, {})",

--- a/src/utils/noise_map_builder.rs
+++ b/src/utils/noise_map_builder.rs
@@ -116,7 +116,7 @@ impl<'a> NoiseMapBuilder<'a> for CylinderMapBuilder<'a> {
                     value, point_x, current_height, point_z
                 );
 
-                result_map.set_value(x, y, value);
+                result_map[(x, y)] = value;
             }
         }
 
@@ -232,7 +232,7 @@ impl<'a> NoiseMapBuilder<'a> for PlaneMapBuilder<'a> {
                     self.source_module.get([current_x, current_y, 0.0])
                 };
 
-                result_map.set_value(x, y, final_value);
+                result_map[(x, y)] = final_value;
             }
         }
 
@@ -332,7 +332,7 @@ impl<'a> NoiseMapBuilder<'a> for SphereMapBuilder<'a> {
 
                 let point = lat_lon_to_xyz(current_lat, current_lon);
 
-                result_map.set_value(x, y, self.source_module.get(point));
+                result_map[(x, y)] = self.source_module.get(point);
             }
         }
 


### PR DESCRIPTION
Implements `Index` and `IndexMut` with 2-dimensional coordinates for NoiseMap as a more ergonomic and efficient alternative to the `get_value` and `set_value` functions, if you are only interested in the data in the map itself. These functions are however preserved for their functionality with the border value. With these trait implementations, one can simply do `map[(x, y)]` to get the value or `map[(x, y)] = new_value` to set the value. This will panic when out of bounds, however.

I've also added `data` and `data_mut` functions to access the underlying vector. This makes it far easier to iterate over the map as you can do `map.data().iter()` or `map.data_mut().iter_mut()`.