### PR TITLE
Revert change from generics to `dyn NoiseFn`

### DIFF
--- a/examples/abs.rs
+++ b/examples/abs.rs
@@ -4,7 +4,7 @@ use noise::{utils::*, Abs, Perlin};
 
 fn main() {
     let perlin = Perlin::default();
-    let abs = Abs::new(&perlin);
+    let abs = Abs::new(perlin);
 
-    PlaneMapBuilder::new(&abs).build().write_to_file("abs.png");
+    PlaneMapBuilder::new(abs).build().write_to_file("abs.png");
 }

--- a/examples/add.rs
+++ b/examples/add.rs
@@ -6,7 +6,7 @@ fn main() {
     let cyl = Cylinders::new();
     let perlin = Perlin::default();
 
-    let add = Add::new(&cyl, &perlin);
+    let add = Add::new(cyl, perlin);
 
     PlaneMapBuilder::new(&add).build().write_to_file("add.png");
 }

--- a/examples/add.rs
+++ b/examples/add.rs
@@ -8,5 +8,5 @@ fn main() {
 
     let add = Add::new(cyl, perlin);
 
-    PlaneMapBuilder::new(&add).build().write_to_file("add.png");
+    PlaneMapBuilder::new(add).build().write_to_file("add.png");
 }

--- a/examples/basicmulti.rs
+++ b/examples/basicmulti.rs
@@ -5,7 +5,7 @@ extern crate noise;
 use noise::{utils::*, BasicMulti};
 
 fn main() {
-    PlaneMapBuilder::new(&BasicMulti::default())
+    PlaneMapBuilder::new(BasicMulti::default())
         .build()
         .write_to_file("basicmulti.png");
 }

--- a/examples/billow.rs
+++ b/examples/billow.rs
@@ -5,7 +5,7 @@ extern crate noise;
 use noise::{utils::*, Billow};
 
 fn main() {
-    PlaneMapBuilder::new(&Billow::default())
+    PlaneMapBuilder::new(Billow::default())
         .build()
         .write_to_file("billow.png");
 }

--- a/examples/blend.rs
+++ b/examples/blend.rs
@@ -6,9 +6,9 @@ fn main() {
     let perlin = Perlin::default();
     let ridged = RidgedMulti::default();
     let fbm = Fbm::default();
-    let blend = Blend::new(&perlin, &ridged, &fbm);
+    let blend = Blend::new(perlin, ridged, fbm);
 
-    PlaneMapBuilder::new(&blend)
+    PlaneMapBuilder::new(blend)
         .build()
         .write_to_file("blend.png");
 }

--- a/examples/cache.rs
+++ b/examples/cache.rs
@@ -4,9 +4,9 @@ use noise::{utils::*, Cache, Checkerboard};
 
 fn main() {
     let cboard = Checkerboard::default();
-    let cache = Cache::new(&cboard);
+    let cache = Cache::new(cboard);
 
-    PlaneMapBuilder::new(&cache)
+    PlaneMapBuilder::new(cache)
         .build()
         .write_to_file("cache.png");
 }

--- a/examples/checkerboard.rs
+++ b/examples/checkerboard.rs
@@ -5,9 +5,11 @@ extern crate noise;
 use noise::{utils::*, Checkerboard};
 
 fn main() {
-    let checker = Checkerboard::default();
+    let checker = Checkerboard::new(0);
 
-    PlaneMapBuilder::new(&checker)
+    PlaneMapBuilder::new(checker)
+        .set_x_bounds(-5.0, 5.0)
+        .set_y_bounds(-5.0, 5.0)
         .build()
         .write_to_file("checkerboard.png");
 }

--- a/examples/clamp.rs
+++ b/examples/clamp.rs
@@ -4,11 +4,9 @@ use noise::{utils::*, Clamp, Perlin};
 
 fn main() {
     let perlin = Perlin::default();
-    let clamp = Clamp::new(&perlin)
-        .set_lower_bound(0.0)
-        .set_upper_bound(0.5);
+    let clamp = Clamp::new(perlin).set_lower_bound(0.0).set_upper_bound(0.5);
 
-    PlaneMapBuilder::new(&clamp)
+    PlaneMapBuilder::new(clamp)
         .build()
         .write_to_file("clamp.png");
 }

--- a/examples/complexplanet.rs
+++ b/examples/complexplanet.rs
@@ -164,103 +164,106 @@ fn main() {
     // -1.0 represents the lowest elevations and +1.0 represents the highest
     // elevations.
     //
+    fn baseContinentDef() -> impl NoiseFn<f64, 3> {
+        // 1: [Continent module]: This FBM module generates the continents. This
+        // noise function has a high number of octaves so that detail is visible at
+        // high zoom levels.
+        let baseContinentDef_fb0 = Fbm::new(CURRENT_SEED)
+            .set_frequency(CONTINENT_FREQUENCY)
+            .set_persistence(0.5)
+            .set_lacunarity(CONTINENT_LACUNARITY)
+            .set_octaves(14);
 
-    // 1: [Continent module]: This FBM module generates the continents. This
-    // noise function has a high number of octaves so that detail is visible at
-    // high zoom levels.
-    let baseContinentDef_fb0 = Fbm::new(CURRENT_SEED)
-        .set_frequency(CONTINENT_FREQUENCY)
-        .set_persistence(0.5)
-        .set_lacunarity(CONTINENT_LACUNARITY)
-        .set_octaves(14);
+        //    debug::render_noise_module("complexplanet_images/00_0_baseContinentDef_fb0\
+        //    .png",
+        //                               &baseContinentDef_fb0,
+        //                               1024,
+        //                               1024,
+        //                               100);
 
-    //    debug::render_noise_module("complexplanet_images/00_0_baseContinentDef_fb0\
-    //    .png",
-    //                               &baseContinentDef_fb0,
-    //                               1024,
-    //                               1024,
-    //                               100);
+        // 2: [Continent-with-ranges module]: Next, a curve module modifies the
+        // output value from the continent module so that very high values appear
+        // near sea level. This defines the positions of the mountain ranges.
+        let baseContinentDef_cu = Curve::new(baseContinentDef_fb0)
+            .add_control_point(-2.0000 + SEA_LEVEL, -1.625 + SEA_LEVEL)
+            .add_control_point(-1.0000 + SEA_LEVEL, -1.375 + SEA_LEVEL)
+            .add_control_point(0.0000 + SEA_LEVEL, -0.375 + SEA_LEVEL)
+            .add_control_point(0.0625 + SEA_LEVEL, 0.125 + SEA_LEVEL)
+            .add_control_point(0.1250 + SEA_LEVEL, 0.250 + SEA_LEVEL)
+            .add_control_point(0.2500 + SEA_LEVEL, 1.000 + SEA_LEVEL)
+            .add_control_point(0.5000 + SEA_LEVEL, 0.250 + SEA_LEVEL)
+            .add_control_point(0.7500 + SEA_LEVEL, 0.250 + SEA_LEVEL)
+            .add_control_point(1.0000 + SEA_LEVEL, 0.500 + SEA_LEVEL)
+            .add_control_point(2.0000 + SEA_LEVEL, 0.500 + SEA_LEVEL);
 
-    // 2: [Continent-with-ranges module]: Next, a curve module modifies the
-    // output value from the continent module so that very high values appear
-    // near sea level. This defines the positions of the mountain ranges.
-    let baseContinentDef_cu = Curve::new(&baseContinentDef_fb0)
-        .add_control_point(-2.0000 + SEA_LEVEL, -1.625 + SEA_LEVEL)
-        .add_control_point(-1.0000 + SEA_LEVEL, -1.375 + SEA_LEVEL)
-        .add_control_point(0.0000 + SEA_LEVEL, -0.375 + SEA_LEVEL)
-        .add_control_point(0.0625 + SEA_LEVEL, 0.125 + SEA_LEVEL)
-        .add_control_point(0.1250 + SEA_LEVEL, 0.250 + SEA_LEVEL)
-        .add_control_point(0.2500 + SEA_LEVEL, 1.000 + SEA_LEVEL)
-        .add_control_point(0.5000 + SEA_LEVEL, 0.250 + SEA_LEVEL)
-        .add_control_point(0.7500 + SEA_LEVEL, 0.250 + SEA_LEVEL)
-        .add_control_point(1.0000 + SEA_LEVEL, 0.500 + SEA_LEVEL)
-        .add_control_point(2.0000 + SEA_LEVEL, 0.500 + SEA_LEVEL);
+        //    debug::render_noise_module("complexplanet_images/00_1_baseContinentDef_cu\
+        //    .png",
+        //                               &baseContinentDef_cu,
+        //                               1024,
+        //                               1024,
+        //                               100);
 
-    //    debug::render_noise_module("complexplanet_images/00_1_baseContinentDef_cu\
-    //    .png",
-    //                               &baseContinentDef_cu,
-    //                               1024,
-    //                               1024,
-    //                               100);
+        // 3: [Carver module]: This higher-frequency BasicMulti module will be
+        // used by subsequent noise functions to carve out chunks from the
+        // mountain ranges within the continent-with-ranges module so that the
+        // mountain ranges will not be completely impassible.
+        let baseContinentDef_fb1 = Fbm::new(CURRENT_SEED + 1)
+            .set_frequency(CONTINENT_FREQUENCY * 4.34375)
+            .set_persistence(0.5)
+            .set_lacunarity(CONTINENT_LACUNARITY)
+            .set_octaves(11);
 
-    // 3: [Carver module]: This higher-frequency BasicMulti module will be
-    // used by subsequent noise functions to carve out chunks from the
-    // mountain ranges within the continent-with-ranges module so that the
-    // mountain ranges will not be completely impassible.
-    let baseContinentDef_fb1 = Fbm::new(CURRENT_SEED + 1)
-        .set_frequency(CONTINENT_FREQUENCY * 4.34375)
-        .set_persistence(0.5)
-        .set_lacunarity(CONTINENT_LACUNARITY)
-        .set_octaves(11);
+        //    debug::render_noise_module("complexplanet_images/00_2_baseContinentDef_fb1\
+        //    .png",
+        //                               &baseContinentDef_fb1,
+        //                               1024,
+        //                               1024,
+        //                               100);
 
-    //    debug::render_noise_module("complexplanet_images/00_2_baseContinentDef_fb1\
-    //    .png",
-    //                               &baseContinentDef_fb1,
-    //                               1024,
-    //                               1024,
-    //                               100);
+        // 4: [Scaled-carver module]: This scale/bias module scales the output
+        // value from the carver module such that it is usually near 1.0. This
+        // is required for step 5.
+        let baseContinentDef_sb = ScaleBias::new(baseContinentDef_fb1)
+            .set_scale(0.375)
+            .set_bias(0.625);
 
-    // 4: [Scaled-carver module]: This scale/bias module scales the output
-    // value from the carver module such that it is usually near 1.0. This
-    // is required for step 5.
-    let baseContinentDef_sb = ScaleBias::new(&baseContinentDef_fb1)
-        .set_scale(0.375)
-        .set_bias(0.625);
+        //    debug::render_noise_module("complexplanet_images/00_3_baseContinentDef_sb\
+        //    .png",
+        //                               &baseContinentDef_sb,
+        //                               1024,
+        //                               1024,
+        //                               100);
 
-    //    debug::render_noise_module("complexplanet_images/00_3_baseContinentDef_sb\
-    //    .png",
-    //                               &baseContinentDef_sb,
-    //                               1024,
-    //                               1024,
-    //                               100);
+        // 5: [Carved-continent module]: This minimum-value module carves out
+        // chunks from the continent-with-ranges module. it does this by ensuring
+        // that only the minimum of the output values from the scaled-carver
+        // module and the continent-with-ranges module contributes to the output
+        // value of this subgroup. Most of the time, the minimum value module will
+        // select the output value from the continent-with-ranges module since the
+        // output value from the scaled-carver is usually near 1.0. Occasionally,
+        // the output from the scaled-carver module will be less than the output
+        // value from the continent-with-ranges module, so in this case, the output
+        // value from the scaled-carver module is selected.
+        let baseContinentDef_mi = Min::new(baseContinentDef_sb, baseContinentDef_cu);
 
-    // 5: [Carved-continent module]: This minimum-value module carves out
-    // chunks from the continent-with-ranges module. it does this by ensuring
-    // that only the minimum of the output values from the scaled-carver
-    // module and the continent-with-ranges module contributes to the output
-    // value of this subgroup. Most of the time, the minimum value module will
-    // select the output value from the continent-with-ranges module since the
-    // output value from the scaled-carver is usually near 1.0. Occasionally,
-    // the output from the scaled-carver module will be less than the output
-    // value from the continent-with-ranges module, so in this case, the output
-    // value from the scaled-carver module is selected.
-    let baseContinentDef_mi = Min::new(&baseContinentDef_sb, &baseContinentDef_cu);
+        //    debug::render_noise_module("complexplanet_images/00_4_baseContinentDef_mi\
+        //    .png",
+        //                               &baseContinentDef_mi,
+        //                               1024,
+        //                               1024,
+        //                               100);
 
-    //    debug::render_noise_module("complexplanet_images/00_4_baseContinentDef_mi\
-    //    .png",
-    //                               &baseContinentDef_mi,
-    //                               1024,
-    //                               1024,
-    //                               100);
+        // 6: [Clamped-continent module]: Finally, a clamp module modifies the
+        // carved continent module to ensure that the output value of this subgroup
+        // is between -1.0 and 1.0.
+        let baseContinentDef_cl = Clamp::new(baseContinentDef_mi).set_bounds(-1.0, 1.0);
 
-    // 6: [Clamped-continent module]: Finally, a clamp module modifies the
-    // carved continent module to ensure that the output value of this subgroup
-    // is between -1.0 and 1.0.
-    let baseContinentDef_cl = Clamp::new(&baseContinentDef_mi).set_bounds(-1.0, 1.0);
+        // 7: [Base-continent-definition subgroup]: Caches the output value from
+        // the clamped-continent module.
+        let baseContinentDef = Cache::new(baseContinentDef_cl);
 
-    // 7: [Base-continent-definition subgroup]: Caches the output value from
-    // the clamped-continent module.
-    let baseContinentDef = Cache::new(baseContinentDef_cl);
+        baseContinentDef
+    }
 
     //    debug::render_noise_module("complexplanet_images/00_5_baseContinentDef.png",
     //                               &baseContinentDef,
@@ -284,7 +287,7 @@ fn main() {
     // 1: [Coarse-turbulence module]: This turbulence module warps the output
     // value from the base-continent-definition subgroup, adding some coarse
     // detail to it.
-    let continentDef_tu0 = Turbulence::new(&baseContinentDef)
+    let continentDef_tu0 = Turbulence::new(baseContinentDef())
         .set_seed(CURRENT_SEED + 10)
         .set_frequency(CONTINENT_FREQUENCY * 15.25)
         .set_power(CONTINENT_FREQUENCY / 113.75)
@@ -338,7 +341,7 @@ fn main() {
     // transition.  In effect, only the higher areas of the base-continent-
     // definition subgroup become warped; the underwater and coastal areas
     // remain unaffected.
-    let continentDef_se = Select::new(&baseContinentDef, &continentDef_tu2, &baseContinentDef)
+    let continentDef_se = Select::new(baseContinentDef(), continentDef_tu2, baseContinentDef())
         .set_bounds(SEA_LEVEL - 0.0375, SEA_LEVEL + 1000.0375)
         .set_falloff(0.0625);
 
@@ -395,7 +398,7 @@ fn main() {
     // slope towards the higher-elevation areas. This shrinks the areas in
     // which the rough terrain appears, increasing the "rarity" of rough
     // terrain.
-    let terrainTypeDef_te = Terrace::new(&terrainTypeDef_tu)
+    let terrainTypeDef_te = Terrace::new(terrainTypeDef_tu)
         .add_control_point(-1.00)
         .add_control_point(SHELF_LEVEL + SEA_LEVEL / 2.0)
         .add_control_point(1.00);
@@ -430,7 +433,7 @@ fn main() {
     // output value from the mountain-ridge module so that its ridges are not
     // too high. The reason for this is that another subgroup adds actual
     // mountainous terrain to these ridges.
-    let mountainBaseDef_sb0 = ScaleBias::new(&mountainBaseDef_rm0)
+    let mountainBaseDef_sb0 = ScaleBias::new(mountainBaseDef_rm0)
         .set_scale(0.5)
         .set_bias(0.375);
 
@@ -452,7 +455,7 @@ fn main() {
     // octave ridged-multifractal noise. The negative scaling factor inverts
     // the range of the output value, turning the ridges from the river-valley
     // module into valleys.
-    let mountainBaseDef_sb1 = ScaleBias::new(&mountainBaseDef_rm1)
+    let mountainBaseDef_sb1 = ScaleBias::new(mountainBaseDef_rm1)
         .set_scale(-2.0)
         .set_bias(-0.5);
 
@@ -526,7 +529,7 @@ fn main() {
     // that only the maximum of the output values from the two ridged-
     // multifractal-noise functions contribute to the output value of this
     // subgroup.
-    let mountainousHigh_ma = Max::new(&mountainousHigh_rm0, &mountainousHigh_rm1);
+    let mountainousHigh_ma = Max::new(mountainousHigh_rm0, mountainousHigh_rm1);
 
     // 4: [Warped-high-mountains module]: This turbulence module warps the
     // output value from the high-mountains module, adding some detail to it.
@@ -573,7 +576,7 @@ fn main() {
     // - Flat areas appear when a positive and a negative output value are
     //   multiplied together.
     // - Ridges appear when two positive output values are multiplied together.
-    let mountainousLow_mu = Multiply::new(&mountainousLow_rm0, &mountainousLow_rm1);
+    let mountainousLow_mu = Multiply::new(mountainousLow_rm0, mountainousLow_rm1);
 
     // 4: [Low-mountainous-terrain subgroup]: Caches the output value from the
     // low-mountainous-terrain module.
@@ -596,7 +599,7 @@ fn main() {
     // areas becoming more-or-less flat with little variation. This will also
     // result in the low mountainous areas appearing at the lowest elevations in
     // this subgroup.
-    let mountainousTerrain_sb0 = ScaleBias::new(&mountainousLow)
+    let mountainousTerrain_sb0 = ScaleBias::new(mountainousLow)
         .set_scale(0.03125)
         .set_bias(-0.96875);
 
@@ -604,7 +607,7 @@ fn main() {
     // scales the output value from the high-mountainous-terrain subgroup to 1/4
     // of its initial value and biases it so that its output value is usually
     // positive.
-    let mountainousTerrain_sb1 = ScaleBias::new(&mountainousHigh)
+    let mountainousTerrain_sb1 = ScaleBias::new(mountainousHigh)
         .set_scale(0.25)
         .set_bias(0.25);
 
@@ -612,7 +615,7 @@ fn main() {
     // output value from the scaled-high-mountainous-terrain module to the
     // output value from the mountain-base-definition subgroup. Mountains now
     // appear all over the terrain.
-    let mountainousTerrain_ad = Add::new(&mountainousTerrain_sb1, &mountainBaseDef);
+    let mountainousTerrain_ad = Add::new(mountainousTerrain_sb1, &mountainBaseDef);
 
     // 4: [Combined-mountainous-terrain module]: Note that at this point, the
     // entire terrain is covered in high mountainous terrain, even at the low
@@ -626,8 +629,8 @@ fn main() {
     // module selects the output value from the scaled-low-mountainous-terrain
     // module.
     let mountainousTerrain_se = Select::new(
-        &mountainousTerrain_sb0,
-        &mountainousTerrain_ad,
+        mountainousTerrain_sb0,
+        mountainousTerrain_ad,
         &mountainBaseDef,
     )
     .set_bounds(-0.5, 999.5)
@@ -636,7 +639,7 @@ fn main() {
     // 5: [Scaled-mountainous-terrain-module]: This scale/bias module slightly
     // reduces the range of the output value from the combined-mountainous-
     // terrain module, decreasing the heights of the mountain peaks.
-    let mountainousTerrain_sb2 = ScaleBias::new(&mountainousTerrain_se)
+    let mountainousTerrain_sb2 = ScaleBias::new(mountainousTerrain_se)
         .set_scale(0.8)
         .set_bias(0.0);
 
@@ -647,7 +650,7 @@ fn main() {
     // those mountains. This exponential-curve module expects the output value
     // to range from -1.0 to +1.0.
     let mountainousTerrain_ex =
-        Exponent::new(&mountainousTerrain_sb2).set_exponent(MOUNTAIN_GLACIATION);
+        Exponent::new(mountainousTerrain_sb2).set_exponent(MOUNTAIN_GLACIATION);
 
     let mountainousTerrain = Cache::new(mountainousTerrain_ex);
 
@@ -675,9 +678,7 @@ fn main() {
     // value from the hills module so that its hilltops are not too high. The
     // reason for this is that these hills are eventually added to the river
     // valleys (see below).
-    let hillyTerrain_sb0 = ScaleBias::new(&hillyTerrain_bi)
-        .set_scale(0.5)
-        .set_bias(0.5);
+    let hillyTerrain_sb0 = ScaleBias::new(hillyTerrain_bi).set_scale(0.5).set_bias(0.5);
 
     // 3: [River-valley module]: This ridged-multifractal-noise function generates
     // the river valleys. It has a much lower frequency so that more hills will
@@ -696,7 +697,7 @@ fn main() {
     // octave ridged-multifractal noise. The negative scaling factor inverts
     // the range of the output value, turning the ridges from the river-valley
     // module into valleys.
-    let hillyTerrain_sb1 = ScaleBias::new(&hillyTerrain_rm)
+    let hillyTerrain_sb1 = ScaleBias::new(hillyTerrain_rm)
         .set_scale(-2.0)
         .set_bias(-1.0);
 
@@ -710,12 +711,12 @@ fn main() {
     // scaled-hills module as the control module, causing the low-flat module to
     // appear in the lower areas and causing the scaled-river-valley module to
     // appear in the higher areas.
-    let hillyTerrain_bl = Blend::new(&hillyTerrain_co, &hillyTerrain_sb1, &hillyTerrain_sb0);
+    let hillyTerrain_bl = Blend::new(hillyTerrain_co, hillyTerrain_sb1, hillyTerrain_sb0);
 
     // 7: [Scaled-hills-and-valleys module]: This scale/bias module slightly
     // reduces the range of the output value from the hills-and-valleys
     // module, decreasing the heights of the hilltops.
-    let hillyTerrain_sb2 = ScaleBias::new(&hillyTerrain_bl)
+    let hillyTerrain_sb2 = ScaleBias::new(hillyTerrain_bl)
         .set_scale(0.75)
         .set_bias(-0.25);
 
@@ -724,7 +725,7 @@ fn main() {
     // exponential curve to the output value the scaled-hills-and-valleys
     // module. This exponential-curve module expects the input value to range
     // from -1.0 to 1.0.
-    let hillyTerrain_ex = Exponent::new(&hillyTerrain_sb2).set_exponent(1.375);
+    let hillyTerrain_ex = Exponent::new(hillyTerrain_sb2).set_exponent(1.375);
 
     // 9: [Coarse-turbulence module]: This turbulence module warps the output
     // value from the increased-slope-hilly-terrain module, adding some
@@ -779,7 +780,7 @@ fn main() {
     // output value from the plains-basis-0 module positive since this output
     // value will be multiplied together with the positive-plains-basis-1
     // module.
-    let plainsTerrain_sb0 = ScaleBias::new(&plainsTerrain_bi0)
+    let plainsTerrain_sb0 = ScaleBias::new(plainsTerrain_bi0)
         .set_scale(0.5)
         .set_bias(0.5);
 
@@ -795,18 +796,18 @@ fn main() {
     // output value from the plains-basis-1 module positive since this output
     // value will be multiplied together with the positive-plains-basis-0
     // module.
-    let plainsTerrain_sb1 = ScaleBias::new(&plainsTerrain_bi1)
+    let plainsTerrain_sb1 = ScaleBias::new(plainsTerrain_bi1)
         .set_scale(0.5)
         .set_bias(0.5);
 
     // 5: [Combined-plains-basis module]: This multiplication module combines
     // the two plains basis modules together.
-    let plainsTerrain_mu = Multiply::new(&plainsTerrain_sb0, &plainsTerrain_sb1);
+    let plainsTerrain_mu = Multiply::new(plainsTerrain_sb0, plainsTerrain_sb1);
 
     // 6: [Rescaled-plains-basis module]: This scale/bias module maps the output
     // value that ranges from 0.0 to 1.0 back to a value that ranges from
     // -1.0 to +1.0.
-    let plainsTerrain_sb2 = ScaleBias::new(&plainsTerrain_mu)
+    let plainsTerrain_sb2 = ScaleBias::new(plainsTerrain_mu)
         .set_scale(2.0)
         .set_bias(-1.0);
 
@@ -839,7 +840,7 @@ fn main() {
     // 2: [Scaled-sand-dunes module]: This scale/bias module shrinks the dune
     // heights by a small amount. This is necessary so that the subsequent
     // noise functions in this subgroup can add some detail to the dunes.
-    let badlandsSand_sb0 = ScaleBias::new(&badlandsSand_rm)
+    let badlandsSand_sb0 = ScaleBias::new(badlandsSand_rm)
         .set_scale(0.875)
         .set_bias(0.0);
 
@@ -855,13 +856,13 @@ fn main() {
     // details by a large amount. This is necessary so that the subsequent
     // noise functions in this subgroup can add this detail to the sand-dunes
     // module.
-    let badlandsSand_sb1 = ScaleBias::new(&badlandsSand_wo)
+    let badlandsSand_sb1 = ScaleBias::new(badlandsSand_wo)
         .set_scale(0.25)
         .set_bias(0.25);
 
     // 5: [Dunes-with-detail module]: This addition module combines the scaled-
     // sand-dunes module with the scaled-dune-detail module.
-    let badlandsSand_ad = Add::new(&badlandsSand_sb0, &badlandsSand_sb1);
+    let badlandsSand_ad = Add::new(badlandsSand_sb0, badlandsSand_sb1);
 
     // 6: [Badlands-sand subgroup]: Caches the output value from the dunes-with-
     // detail module.
@@ -889,7 +890,7 @@ fn main() {
     // very shallow, but then its slope increases sharply. At the highest
     // elevations, the curve becomes very flat again. This produces the
     // stereotypical Utah-style desert cliffs.
-    let badlandsCliffs_cu = Curve::new(&badlandsCliffs_fb)
+    let badlandsCliffs_cu = Curve::new(badlandsCliffs_fb)
         .add_control_point(-2.000, -2.000)
         .add_control_point(-1.000, -1.000)
         .add_control_point(-0.000, -0.750)
@@ -901,12 +902,12 @@ fn main() {
     // 3: [Clamped-cliffs module]: This clamping module makes the tops of the
     // cliffs very flat by clamping the output value from the cliff-shaping
     // module.
-    let badlandsCliffs_cl = Clamp::new(&badlandsCliffs_cu).set_bounds(-999.125, 0.875);
+    let badlandsCliffs_cl = Clamp::new(badlandsCliffs_cu).set_bounds(-999.125, 0.875);
 
     // 4: [Terraced-cliffs module]: Next, this terracing module applies some
     // terraces to the clamped-cliffs module in the lower elevations before the
     // sharp cliff transition.
-    let badlandsCliffs_te = Terrace::new(&badlandsCliffs_cl)
+    let badlandsCliffs_te = Terrace::new(badlandsCliffs_cl)
         .add_control_point(-1.000)
         .add_control_point(-0.875)
         .add_control_point(-0.750)
@@ -954,15 +955,13 @@ fn main() {
     // 1: [Scaled-sand-dunes module]: This scale/bias module considerably
     // flattens the output value from the badlands-sands subgroup and lowers
     // this value to near -1.0.
-    let badlandsTerrain_sb = ScaleBias::new(&badlandsSand)
-        .set_scale(0.25)
-        .set_bias(-0.75);
+    let badlandsTerrain_sb = ScaleBias::new(badlandsSand).set_scale(0.25).set_bias(-0.75);
 
     // 2: [Dunes-and-cliffs module]: This maximum-value module causes the dunes
     // to appear in the low areas and the cliffs to appear in the high areas.
     // It does this by selecting the maximum of the output values from the
     // scaled-sand-dunes module and the badlands-cliffs subgroup.
-    let badlandsTerrain_ma = Max::new(&badlandsCliffs, &badlandsTerrain_sb);
+    let badlandsTerrain_ma = Max::new(badlandsCliffs, badlandsTerrain_sb);
 
     // 3: [Badlands-terrain group]: Caches the output value from the dunes-and-
     // cliffs module. This is the output value for the entire badlands-terrain
@@ -1000,7 +999,7 @@ fn main() {
     // inverted. This creates the rivers. This curve also compresses the edge of
     // the rivers, producing a sharp transition from the land to the river
     // bottom.
-    let riverPositions_cu0 = Curve::new(&riverPositions_rm0)
+    let riverPositions_cu0 = Curve::new(riverPositions_rm0)
         .add_control_point(-2.000, 2.000)
         .add_control_point(-1.000, 1.000)
         .add_control_point(-0.125, 0.875)
@@ -1020,7 +1019,7 @@ fn main() {
     // inverted. This creates the rivers. This curve also compresses the edge of
     // the rivers, producing a sharp transition from the land to the river
     // bottom.
-    let riverPositions_cu1 = Curve::new(&riverPositions_rm1)
+    let riverPositions_cu1 = Curve::new(riverPositions_rm1)
         .add_control_point(-2.000, 2.0000)
         .add_control_point(-1.000, 1.5000)
         .add_control_point(-0.125, 1.4375)
@@ -1032,7 +1031,7 @@ fn main() {
     // rivers to cut into the large rivers.  It does this by selecting the
     // minimum output values from the large-river-curve module and the small-
     // river-curve module.
-    let riverPositions_mi = Min::new(&riverPositions_cu0, &riverPositions_cu1);
+    let riverPositions_mi = Min::new(riverPositions_cu0, riverPositions_cu1);
 
     // 6: [Warped-rivers module]: This turbulence module warps the output value
     //    from the combined-rivers module, which twists the rivers.  The high
@@ -1072,7 +1071,7 @@ fn main() {
     // 1: [Base-scaled-mountainous-terrain module]: This scale/bias module
     // scales the output value from the mountainous-terrain group so that the
     // output value is measured in planetary elevation units.
-    let scaledMountainousTerrain_sb0 = ScaleBias::new(&mountainousTerrain)
+    let scaledMountainousTerrain_sb0 = ScaleBias::new(mountainousTerrain)
         .set_scale(0.125)
         .set_bias(0.125);
 
@@ -1092,14 +1091,13 @@ fn main() {
     // number of low values. This means there will be a few peaks with much
     // higher elevations than the majority of the peaks, making the terrain
     // features more varied.
-    let scaledMountainousTerrain_ex =
-        Exponent::new(&scaledMountainousTerrain_fb).set_exponent(1.25);
+    let scaledMountainousTerrain_ex = Exponent::new(scaledMountainousTerrain_fb).set_exponent(1.25);
 
     // 4: [Scaled-peak-modulation module]: This scale/bias module modifies the
     // range of the output value from the peak-modulation module so that it can
     // be used as the modulator for the peak-height-multiplier module. It is
     // important that this output value is not much lower than 1.0.
-    let scaledMountainousTerrain_sb1 = ScaleBias::new(&scaledMountainousTerrain_ex)
+    let scaledMountainousTerrain_sb1 = ScaleBias::new(scaledMountainousTerrain_ex)
         .set_scale(0.25)
         .set_bias(1.0);
 
@@ -1107,7 +1105,7 @@ fn main() {
     // heights of the mountain peaks from the base-scaled-mountainous-terrain
     // module using the output value from the scaled-peak-modulation module.
     let scaledMountainousTerrain_mu =
-        Multiply::new(&scaledMountainousTerrain_sb0, &scaledMountainousTerrain_sb1);
+        Multiply::new(scaledMountainousTerrain_sb0, scaledMountainousTerrain_sb1);
 
     // 6: [Scaled-mountainous-terrain group]: Caches the output value from the
     // peak-height-multiplier module.  This is the output value for the
@@ -1139,7 +1137,7 @@ fn main() {
     // 1: [Base-scaled-hilly-terrain module]: This scale/bias module scales the
     // output value from the hilly-terrain group so that this output value is
     // measured in planetary elevation units.
-    let scaledHillyTerrain_sb0 = ScaleBias::new(&hillyTerrain)
+    let scaledHillyTerrain_sb0 = ScaleBias::new(hillyTerrain)
         .set_scale(0.0625)
         .set_bias(0.0625);
 
@@ -1159,20 +1157,20 @@ fn main() {
     // number of low values. This means there will be a few hilltops with
     // much higher elevations than the majority of the hilltops, making the
     // terrain features more varied.
-    let scaledHillyTerrain_ex = Exponent::new(&scaledHillyTerrain_fb).set_exponent(1.25);
+    let scaledHillyTerrain_ex = Exponent::new(scaledHillyTerrain_fb).set_exponent(1.25);
 
     // 4: [Scaled-hilltop-modulation module]: This scale/bias module modifies
     // the range of the output value from the hilltop-modulation module so that
     // it can be used as the modulator for the hilltop-height-multiplier module.
     // It is important that this output value is not much lower than 1.0.
-    let scaledHillyTerrain_sb1 = ScaleBias::new(&scaledHillyTerrain_ex)
+    let scaledHillyTerrain_sb1 = ScaleBias::new(scaledHillyTerrain_ex)
         .set_scale(0.5)
         .set_bias(1.5);
 
     // 5: [Hilltop-height-multiplier module]: This multiplier module modulates
     // the heights of the hilltops from the base-scaled-hilly-terrain module
     // using the output value from the scaled-hilltop-modulation module.
-    let scaledHillyTerrain_mu = Multiply::new(&scaledHillyTerrain_sb0, &scaledHillyTerrain_sb1);
+    let scaledHillyTerrain_mu = Multiply::new(scaledHillyTerrain_sb0, scaledHillyTerrain_sb1);
 
     // 6: [Scaled-hilly-terrain group]: Caches the output value from the
     // hilltop-height-multiplier module. This is the output value for the entire
@@ -1203,7 +1201,7 @@ fn main() {
     // 1: [Scaled-plains-terrain module]: This scale/bias module greatly
     // flattens the output value from the plains terrain.  This output value
     // is measured in planetary elevation units.
-    let scaledPlainsTerrain_sb0 = ScaleBias::new(&plainsTerrain)
+    let scaledPlainsTerrain_sb0 = ScaleBias::new(plainsTerrain)
         .set_scale(0.00390625)
         .set_bias(0.0078125);
 
@@ -1236,7 +1234,7 @@ fn main() {
     // 1: [Scaled-badlands-terrain module]: This scale/bias module scales the
     // output value from the badlands-terrain group so that it is measured
     // in planetary elevation units.
-    let scaledBadlandsTerrain_sb = ScaleBias::new(&badlandsTerrain)
+    let scaledBadlandsTerrain_sb = ScaleBias::new(badlandsTerrain)
         .set_scale(0.0625)
         .set_bias(0.0625);
 
@@ -1290,7 +1288,7 @@ fn main() {
     // value from the shelf-creator module so that its possible range is from
     // the bottom of the ocean to sea level. This is done because this subgroup
     // is only concerned about the oceans.
-    let continentalShelf_cl = Clamp::new(&continentalShelf_te).set_bounds(-0.75, SEA_LEVEL);
+    let continentalShelf_cl = Clamp::new(continentalShelf_te).set_bounds(-0.75, SEA_LEVEL);
 
     //    debug::render_noise_module("complexplanet_images/18_1_continentalShelf_cl\
     //    .png",
@@ -1318,7 +1316,7 @@ fn main() {
     // from the oceanic-trench-basis-module so that the ridges become trenches.
     // This noise function also reduces the depth of the trenches so that their
     // depths are measured in planetary elevation units.
-    let continentalShelf_sb = ScaleBias::new(&continentalShelf_rm)
+    let continentalShelf_sb = ScaleBias::new(continentalShelf_rm)
         .set_scale(-0.125)
         .set_bias(-0.125);
 
@@ -1331,7 +1329,7 @@ fn main() {
 
     // 5: [Shelf-and-trenches module]: This addition module adds the oceanic
     // trenches to the clamped-sea-bottom module.
-    let continentalShelf_ad = Add::new(&continentalShelf_sb, &continentalShelf_cl);
+    let continentalShelf_ad = Add::new(continentalShelf_sb, continentalShelf_cl);
 
     // 6: [Continental-shelf subgroup]: Caches the output value from the shelf-
     //    and-trenches module.
@@ -1375,7 +1373,7 @@ fn main() {
     // continent-definition group is below the shelf level. Otherwise, it
     // selects the output value from the base-scaled-continent-elevations
     // module.
-    let baseContinentElev_se = Select::new(&baseContinentElev_sb, &continentalShelf, &continentDef)
+    let baseContinentElev_se = Select::new(baseContinentElev_sb, continentalShelf, &continentDef)
         .set_bounds(SHELF_LEVEL - 1000.0, SHELF_LEVEL)
         .set_falloff(0.03125);
 
@@ -1403,7 +1401,7 @@ fn main() {
 
     // 1: [Continents-with-plains module]: This addition module adds the scaled-
     // plains-terrain group to the base-continent-elevation subgroup.
-    let continentsWithPlains_ad = Add::new(&baseContinentElev, &scaledPlainsTerrain);
+    let continentsWithPlains_ad = Add::new(&baseContinentElev, scaledPlainsTerrain);
 
     // 2: [Continents-with-plains subgroup]: Caches the output value from the
     // continents-with-plains module.
@@ -1429,7 +1427,7 @@ fn main() {
 
     // 1: [Continents-with-hills module]: This addition module adds the scaled-
     // hilly-terrain group to the base-continent-elevation subgroup.
-    let continentsWithHills_ad = Add::new(&baseContinentElev, &scaledHillyTerrain);
+    let continentsWithHills_ad = Add::new(&baseContinentElev, scaledHillyTerrain);
 
     //    debug::render_noise_module("complexplanet_images/21_0_continentsWithHills_ad.png",
     //                               &continentsWithHills_ad,
@@ -1476,7 +1474,7 @@ fn main() {
     // 1: [Continents-and-mountains module]: This addition module adds the
     // scaled-mountainous-terrain group to the base-continent-elevation
     // subgroup.
-    let continentsWithMountains_ad0 = Add::new(&baseContinentElev, &scaledMountainousTerrain);
+    let continentsWithMountains_ad0 = Add::new(&baseContinentElev, scaledMountainousTerrain);
 
     //    debug::render_noise_module("complexplanet_images/22_0_continentsWithMountains_ad0.png",
     //                               &continentsWithMountains_ad0,
@@ -1505,7 +1503,7 @@ fn main() {
     // increased-mountain-heights module to the continents-and-mountains module.
     // The highest continent elevations now have the highest mountains.
     let continentsWithMountains_ad1 =
-        Add::new(&continentsWithMountains_ad0, &continentsWithMountains_cu);
+        Add::new(continentsWithMountains_ad0, continentsWithMountains_cu);
 
     //    debug::render_noise_module("complexplanet_images/22_2_continentsWithMountains_ad1.png",
     //                               &continentsWithMountains_ad1,
@@ -1521,8 +1519,8 @@ fn main() {
     // continents-with-hills subgroup. Note that the continents-with-hills
     // subgroup also contains the plains terrain.
     let continentsWithMountains_se = Select::new(
-        &continentsWithHills,
-        &continentsWithMountains_ad1,
+        continentsWithHills,
+        continentsWithMountains_ad1,
         &terrainTypeDef,
     )
     .set_bounds(1.0 - MOUNTAINS_AMOUNT, 1001.0 - MOUNTAINS_AMOUNT)
@@ -1567,7 +1565,7 @@ fn main() {
     // 2: [Continents-and-badlands module]:  This addition module adds the
     // scaled-badlands-terrain group to the base-continent-elevation
     // subgroup.
-    let continentsWithBadlands_ad = Add::new(&baseContinentElev, &scaledBadlandsTerrain);
+    let continentsWithBadlands_ad = Add::new(&baseContinentElev, scaledBadlandsTerrain);
 
     //    debug::render_noise_module("complexplanet_images/23_1_continentsWithBadlands_ad.png",
     //                               &continentsWithBadlands_ad,
@@ -1604,7 +1602,7 @@ fn main() {
     // mountains subgroup and the select-badlands-positions modules contribute
     // to the output value of this subgroup. One side effect of this process is
     // that the badlands will not appear in mountainous terrain.
-    let continentsWithBadlands_ma = Max::new(&continentsWithMountains, &continentsWithBadlands_se);
+    let continentsWithBadlands_ma = Max::new(&continentsWithMountains, continentsWithBadlands_se);
 
     // 5: [Continents-with-badlands subgroup]: Caches the output value from the
     //    apply-badlands module.
@@ -1630,7 +1628,7 @@ fn main() {
     // 1: [Scaled-rivers module]: This scale/bias module scales the output value
     // from the river-positions group so that it is measured in planetary
     // elevation units and is negative; this is required for step 2.
-    let continentsWithRivers_sb = ScaleBias::new(&riverPositions)
+    let continentsWithRivers_sb = ScaleBias::new(riverPositions)
         .set_scale(RIVER_DEPTH / 2.0)
         .set_bias(-RIVER_DEPTH / 2.0);
 
@@ -1644,7 +1642,7 @@ fn main() {
     // rivers to the continents-with-badlands subgroup. Because the scaled-
     // rivers module only outputs a negative value, the scaled-rivers module
     // carves the rivers out of the terrain.
-    let continentsWithRivers_ad = Add::new(&continentsWithBadlands, &continentsWithRivers_sb);
+    let continentsWithRivers_ad = Add::new(&continentsWithBadlands, continentsWithRivers_sb);
 
     //    debug::render_noise_module("complexplanet_images/24_1_continentsWithRivers_ad.png",
     //                               &continentsWithRivers_ad,
@@ -1661,7 +1659,7 @@ fn main() {
     // continents module.
     let continentsWithRivers_se = Select::new(
         &continentsWithBadlands,
-        &continentsWithRivers_ad,
+        continentsWithRivers_ad,
         &continentsWithBadlands,
     )
     .set_bounds(SEA_LEVEL, CONTINENT_HEIGHT_SCALE + SEA_LEVEL)
@@ -1750,4 +1748,14 @@ fn main() {
         .set_gradient(ColorGradient::new().build_terrain_gradient())
         .render(&noise_map)
         .write_to_file("unscaledFinalPlanet_16x_zoom.png");
+
+    ImageRenderer::new()
+        .set_gradient(ColorGradient::new().build_terrain_gradient())
+        .render(
+            &SphereMapBuilder::new(unscaledFinalPlanet)
+                .set_size(1024, 1024)
+                .set_bounds(-90.0, 90.0, -180.0, 180.0)
+                .build(),
+        )
+        .write_to_file("unscaledFinalPlanet_sphere.png");
 }

--- a/examples/constant.rs
+++ b/examples/constant.rs
@@ -5,13 +5,13 @@ extern crate noise;
 use noise::{utils::*, Constant};
 
 fn main() {
-    PlaneMapBuilder::new(&Constant::new(-1.0))
+    PlaneMapBuilder::new(Constant::new(-1.0))
         .build()
         .write_to_file("constant_-1.png");
-    PlaneMapBuilder::new(&Constant::new(0.0))
+    PlaneMapBuilder::new(Constant::new(0.0))
         .build()
         .write_to_file("constant_0.png");
-    PlaneMapBuilder::new(&Constant::new(1.0))
+    PlaneMapBuilder::new(Constant::new(1.0))
         .build()
         .write_to_file("constant_1.png");
 }

--- a/examples/curve.rs
+++ b/examples/curve.rs
@@ -4,7 +4,7 @@ use noise::{utils::*, Curve, Perlin};
 
 fn main() {
     let perlin = Perlin::default();
-    let curve = Curve::new(&perlin)
+    let curve = Curve::new(perlin)
         .add_control_point(-2.0, -2.0)
         .add_control_point(-1.0, -1.25)
         .add_control_point(0.0, -0.75)
@@ -13,7 +13,7 @@ fn main() {
         .add_control_point(0.75, 1.0)
         .add_control_point(2.0, 1.25);
 
-    PlaneMapBuilder::new(&curve)
+    PlaneMapBuilder::new(curve)
         .build()
         .write_to_file("curve.png");
 }

--- a/examples/cylinders.rs
+++ b/examples/cylinders.rs
@@ -3,10 +3,10 @@ extern crate noise;
 use noise::{utils::*, Cylinders};
 
 fn main() {
-    PlaneMapBuilder::new(&Cylinders::new())
+    PlaneMapBuilder::new(Cylinders::new())
         .build()
         .write_to_file("cylinders.png");
-    PlaneMapBuilder::new(&Cylinders::new().set_frequency(5.0))
+    PlaneMapBuilder::new(Cylinders::new().set_frequency(5.0))
         .build()
         .write_to_file("cylinders-f5.png");
 }

--- a/examples/displace.rs
+++ b/examples/displace.rs
@@ -9,7 +9,7 @@ fn main() {
     let perlin = Perlin::default();
     let displace = Displace::new(cylinders, cboard, perlin, constant, constant);
 
-    PlaneMapBuilder::new(&displace)
+    PlaneMapBuilder::new(displace)
         .build()
         .write_to_file("displace.png");
 }

--- a/examples/exponent.rs
+++ b/examples/exponent.rs
@@ -4,9 +4,9 @@ use noise::{utils::*, Exponent, Perlin};
 
 fn main() {
     let perlin = Perlin::default();
-    let exponent = Exponent::new(&perlin).set_exponent(3.0);
+    let exponent = Exponent::new(perlin).set_exponent(3.0);
 
-    PlaneMapBuilder::new(&exponent)
+    PlaneMapBuilder::new(exponent)
         .build()
         .write_to_file("exponent.png");
 }

--- a/examples/fbm.rs
+++ b/examples/fbm.rs
@@ -7,7 +7,7 @@ use noise::{utils::*, Fbm};
 fn main() {
     let fbm = Fbm::default();
 
-    PlaneMapBuilder::new(&fbm)
+    PlaneMapBuilder::new(fbm)
         .set_size(1000, 1000)
         .set_x_bounds(-5.0, 5.0)
         .set_y_bounds(-5.0, 5.0)

--- a/examples/hybridmulti.rs
+++ b/examples/hybridmulti.rs
@@ -7,7 +7,7 @@ use noise::{utils::*, HybridMulti};
 fn main() {
     let hybrid_multi = HybridMulti::default();
 
-    PlaneMapBuilder::new(&hybrid_multi)
+    PlaneMapBuilder::new(hybrid_multi)
         .build()
         .write_to_file("hybrid_multi.png");
 }

--- a/examples/max.rs
+++ b/examples/max.rs
@@ -5,7 +5,7 @@ use noise::{utils::*, Cylinders, Max, Perlin};
 fn main() {
     let cyl = Cylinders::new();
     let perlin = Perlin::default();
-    let max = Max::new(&cyl, &perlin);
+    let max = Max::new(cyl, perlin);
 
     PlaneMapBuilder::new(&max).build().write_to_file("max.png");
 }

--- a/examples/max.rs
+++ b/examples/max.rs
@@ -7,5 +7,5 @@ fn main() {
     let perlin = Perlin::default();
     let max = Max::new(cyl, perlin);
 
-    PlaneMapBuilder::new(&max).build().write_to_file("max.png");
+    PlaneMapBuilder::new(max).build().write_to_file("max.png");
 }

--- a/examples/min.rs
+++ b/examples/min.rs
@@ -7,5 +7,5 @@ fn main() {
     let perlin = Perlin::default();
     let min = Min::new(cyl, perlin);
 
-    PlaneMapBuilder::new(&min).build().write_to_file("min.png");
+    PlaneMapBuilder::new(min).build().write_to_file("min.png");
 }

--- a/examples/min.rs
+++ b/examples/min.rs
@@ -5,7 +5,7 @@ use noise::{utils::*, Cylinders, Min, Perlin};
 fn main() {
     let cyl = Cylinders::new();
     let perlin = Perlin::default();
-    let min = Min::new(&cyl, &perlin);
+    let min = Min::new(cyl, perlin);
 
     PlaneMapBuilder::new(&min).build().write_to_file("min.png");
 }

--- a/examples/multiply.rs
+++ b/examples/multiply.rs
@@ -7,7 +7,7 @@ fn main() {
     let perlin = Perlin::default();
     let multiply = Multiply::new(cyl, perlin);
 
-    PlaneMapBuilder::new(&multiply)
+    PlaneMapBuilder::new(multiply)
         .build()
         .write_to_file("multiply.png");
 }

--- a/examples/multiply.rs
+++ b/examples/multiply.rs
@@ -5,7 +5,7 @@ use noise::{utils::*, Cylinders, Multiply, Perlin};
 fn main() {
     let cyl = Cylinders::new();
     let perlin = Perlin::default();
-    let multiply = Multiply::new(&cyl, &perlin);
+    let multiply = Multiply::new(cyl, perlin);
 
     PlaneMapBuilder::new(&multiply)
         .build()

--- a/examples/negate.rs
+++ b/examples/negate.rs
@@ -4,9 +4,9 @@ use noise::{utils::*, Abs, Negate, Perlin};
 
 fn main() {
     let perlin = Perlin::default();
-    let abs = Abs::new(&perlin);
+    let abs = Abs::new(perlin);
 
-    PlaneMapBuilder::new(&Negate::new(&abs))
+    PlaneMapBuilder::new(Negate::new(abs))
         .build()
         .write_to_file("negate.png");
 }

--- a/examples/open_simplex.rs
+++ b/examples/open_simplex.rs
@@ -7,13 +7,13 @@ use noise::{utils::*, OpenSimplex, Seedable};
 fn main() {
     let open_simplex = OpenSimplex::default();
 
-    PlaneMapBuilder::new(&open_simplex)
+    PlaneMapBuilder::new(open_simplex)
         .build()
         .write_to_file("open_simplex.png");
 
     let open_simplex = open_simplex.set_seed(1);
 
-    PlaneMapBuilder::new(&open_simplex)
+    PlaneMapBuilder::new(open_simplex)
         .build()
         .write_to_file("open_simplex_seed=1.png");
 }

--- a/examples/perlin.rs
+++ b/examples/perlin.rs
@@ -7,7 +7,7 @@ use noise::{utils::*, Perlin, Seedable};
 fn main() {
     let perlin = Perlin::default();
 
-    PlaneMapBuilder::new(&perlin)
+    PlaneMapBuilder::new(perlin)
         .set_size(1024, 1024)
         .set_x_bounds(-5.0, 5.0)
         .set_y_bounds(-5.0, 5.0)
@@ -16,7 +16,7 @@ fn main() {
 
     let perlin = perlin.set_seed(1);
 
-    PlaneMapBuilder::new(&perlin)
+    PlaneMapBuilder::new(perlin)
         .set_size(1024, 1024)
         .set_x_bounds(-5.0, 5.0)
         .set_y_bounds(-5.0, 5.0)

--- a/examples/power.rs
+++ b/examples/power.rs
@@ -7,7 +7,7 @@ fn main() {
     let perlin2 = Perlin::new(1);
     let power = Power::new(perlin1, perlin2);
 
-    PlaneMapBuilder::new(&power)
+    PlaneMapBuilder::new(power)
         .build()
         .write_to_file("power.png");
 }

--- a/examples/power.rs
+++ b/examples/power.rs
@@ -5,7 +5,7 @@ use noise::{utils::*, Perlin, Power, Seedable};
 fn main() {
     let perlin1 = Perlin::default();
     let perlin2 = Perlin::new(1);
-    let power = Power::new(&perlin1, &perlin2);
+    let power = Power::new(perlin1, perlin2);
 
     PlaneMapBuilder::new(&power)
         .build()

--- a/examples/ridgedmulti.rs
+++ b/examples/ridgedmulti.rs
@@ -7,7 +7,7 @@ use noise::{utils::*, RidgedMulti};
 fn main() {
     let ridged_multi = RidgedMulti::default();
 
-    PlaneMapBuilder::new(&ridged_multi)
+    PlaneMapBuilder::new(ridged_multi)
         .build()
         .write_to_file("ridged_multi.png");
 }

--- a/examples/rotate_point.rs
+++ b/examples/rotate_point.rs
@@ -6,7 +6,7 @@ fn main() {
     let cylinders = Cylinders::new();
     let rotate_point = RotatePoint::new(cylinders).set_x_angle(60.0);
 
-    PlaneMapBuilder::new(&rotate_point)
+    PlaneMapBuilder::new(rotate_point)
         .build()
         .write_to_file("rotate_point.png");
 }

--- a/examples/scale_bias.rs
+++ b/examples/scale_bias.rs
@@ -4,9 +4,9 @@ use noise::{utils::*, Perlin, ScaleBias};
 
 fn main() {
     let perlin = Perlin::default();
-    let scale_bias = ScaleBias::new(&perlin).set_scale(0.0625).set_bias(0.0);
+    let scale_bias = ScaleBias::new(perlin).set_scale(0.0625).set_bias(0.0);
 
-    PlaneMapBuilder::new(&scale_bias)
+    PlaneMapBuilder::new(scale_bias)
         .build()
         .write_to_file("scale_bias.png");
 }

--- a/examples/scale_point.rs
+++ b/examples/scale_point.rs
@@ -6,7 +6,7 @@ fn main() {
     let cboard = Checkerboard::default();
     let scale_point = ScalePoint::new(cboard).set_all_scales(1.0, 2.0, 3.0, 1.0);
 
-    PlaneMapBuilder::new(&scale_point)
+    PlaneMapBuilder::new(scale_point)
         .set_size(500, 500)
         .set_x_bounds(-5.0, 5.0)
         .set_y_bounds(-5.0, 5.0)

--- a/examples/select.rs
+++ b/examples/select.rs
@@ -3,21 +3,23 @@ extern crate noise;
 use noise::{utils::*, Checkerboard, Constant, Cylinders, Perlin, Select};
 
 fn main() {
-    let checkerboard = &Checkerboard::default();
-    let cylinders = &Cylinders::new();
-    let perlin = &Perlin::default();
-    let constant = &Constant::new(0.5);
-    let select1 = Select::new(&perlin, &cylinders, &checkerboard)
+    let checkerboard = Checkerboard::default();
+    let cylinders = Cylinders::new();
+    let perlin = Perlin::default();
+    let constant = Constant::new(0.5);
+    let select1 = Select::new(perlin, cylinders, checkerboard)
         .set_bounds(0.0, 1.0)
         .set_falloff(0.5);
-    let select2 = Select::new(&perlin, &constant, &checkerboard)
+    let select2 = Select::new(perlin, constant, checkerboard)
         .set_bounds(0.0, 1.0)
         .set_falloff(0.0);
 
-    PlaneMapBuilder::new(&select1)
+    PlaneMapBuilder::new(select1)
+        .set_x_bounds(-1.0, 1.0)
+        .set_y_bounds(-1.0, 1.0)
         .build()
         .write_to_file("select1.png");
-    PlaneMapBuilder::new(&select2)
+    PlaneMapBuilder::new(select2)
         .build()
         .write_to_file("select2.png");
 }

--- a/examples/simplex.rs
+++ b/examples/simplex.rs
@@ -7,7 +7,7 @@ use noise::{utils::*, Seedable, Simplex};
 fn main() {
     let mut simplex = Simplex::default();
 
-    PlaneMapBuilder::new(&simplex)
+    PlaneMapBuilder::new(simplex)
         .set_size(1024, 1024)
         .set_x_bounds(-5.0, 5.0)
         .set_y_bounds(-5.0, 5.0)
@@ -16,7 +16,7 @@ fn main() {
 
     simplex = simplex.set_seed(1);
 
-    PlaneMapBuilder::new(&simplex)
+    PlaneMapBuilder::new(simplex)
         .set_size(1024, 1024)
         .set_x_bounds(-5.0, 5.0)
         .set_y_bounds(-5.0, 5.0)

--- a/examples/super_simplex.rs
+++ b/examples/super_simplex.rs
@@ -200,13 +200,13 @@ fn main() {
 
     let super_simplex = SuperSimplex::default();
 
-    PlaneMapBuilder::new(&super_simplex)
+    PlaneMapBuilder::new(super_simplex)
         .build()
         .write_to_file("super_simplex.png");
 
     let super_simplex = super_simplex.set_seed(1);
 
-    PlaneMapBuilder::new(&super_simplex)
+    PlaneMapBuilder::new(super_simplex)
         .build()
         .write_to_file("super_simplex_seed=1.png");
 }

--- a/examples/terrace.rs
+++ b/examples/terrace.rs
@@ -4,24 +4,24 @@ use noise::{utils::*, Perlin, Terrace};
 
 fn main() {
     let perlin = Perlin::default();
-    let terrace = Terrace::new(&perlin)
+    let terrace = Terrace::new(perlin)
         .add_control_point(-1.0)
         .add_control_point(-0.5)
         .add_control_point(0.1)
         .add_control_point(1.0);
 
-    let terrace_inverted = Terrace::new(&perlin)
+    let terrace_inverted = Terrace::new(perlin)
         .add_control_point(-1.0)
         .add_control_point(-0.5)
         .add_control_point(0.1)
         .add_control_point(1.0)
         .invert_terraces(true);
 
-    PlaneMapBuilder::new(&terrace)
+    PlaneMapBuilder::new(terrace)
         .build()
         .write_to_file("terrace.png");
 
-    PlaneMapBuilder::new(&terrace_inverted)
+    PlaneMapBuilder::new(terrace_inverted)
         .build()
         .write_to_file("terrace_inverted.png");
 }

--- a/examples/texturegranite.rs
+++ b/examples/texturegranite.rs
@@ -19,10 +19,10 @@ fn main() {
     // Scale the small grain values so that they can be added to the base
     // granite texture. Worley polygons normally generate pits, so apply a
     // negative scaling factor to produce bumps instead.
-    let scaled_grains = ScaleBias::new(&base_grains).set_scale(-0.5).set_bias(0.0);
+    let scaled_grains = ScaleBias::new(base_grains).set_scale(-0.5).set_bias(0.0);
 
     // Combine the primary granite texture with the small grain texture.
-    let combined_granite = Add::new(&primary_granite, &scaled_grains);
+    let combined_granite = Add::new(primary_granite, scaled_grains);
 
     // Finally, perturb the granite texture to add realism.
     let final_granite = Turbulence::new(combined_granite)
@@ -40,7 +40,7 @@ fn main() {
         .set_is_seamless(true)
         .build();
 
-    let sphere_texture = SphereMapBuilder::new(&final_granite)
+    let sphere_texture = SphereMapBuilder::new(final_granite)
         .set_size(1024, 512)
         .set_bounds(-90.0, 90.0, -180.0, 180.0)
         .build();

--- a/examples/texturejade.rs
+++ b/examples/texturejade.rs
@@ -29,14 +29,14 @@ fn main() {
 
     // Scale the secondary jade texture so it makes a small contribution to the
     // final jade texture.
-    let secondary_jade = ScaleBias::new(&perturbed_base_secondary_jade)
+    let secondary_jade = ScaleBias::new(perturbed_base_secondary_jade)
         .set_scale(0.25)
         .set_bias(0.0);
 
     // Add the two jade textures together. These two textures were produced
     // using different combinations of coherent noise, so the final texture
     // will have a lot of variation.
-    let combined_jade = Add::new(&primary_jade, &secondary_jade);
+    let combined_jade = Add::new(primary_jade, secondary_jade);
 
     // Finally, perturb the combined jade texture to produce the final jade
     // texture. A low roughness produces nice veins.
@@ -50,7 +50,7 @@ fn main() {
         .set_size(1024, 1024)
         .build();
 
-    let seamless_texture = PlaneMapBuilder::new(&final_jade)
+    let seamless_texture = PlaneMapBuilder::new(final_jade)
         .set_size(1024, 1024)
         .set_is_seamless(true)
         .build();

--- a/examples/textureslime.rs
+++ b/examples/textureslime.rs
@@ -17,7 +17,7 @@ fn main() {
         .set_octaves(1);
 
     // Scale and lower the small slime bubble values.
-    let small_slime = ScaleBias::new(&small_slime_base)
+    let small_slime = ScaleBias::new(small_slime_base)
         .set_scale(0.5)
         .set_bias(-0.5);
 
@@ -34,7 +34,7 @@ fn main() {
     // values, otherwise choose the large slime bubble texture. The edge
     // falloff is non-zero so that there is a smooth transition between the
     // two textures.
-    let slime_chooser = Select::new(&large_slime, &small_slime, &slime_map)
+    let slime_chooser = Select::new(large_slime, small_slime, slime_map)
         .set_bounds(-0.375, 0.375)
         .set_falloff(0.5);
 
@@ -49,7 +49,7 @@ fn main() {
         .set_size(1024, 1024)
         .build();
 
-    let seamless_texture = PlaneMapBuilder::new(&final_slime)
+    let seamless_texture = PlaneMapBuilder::new(final_slime)
         .set_size(1024, 1024)
         .set_is_seamless(true)
         .build();

--- a/examples/texturewood.rs
+++ b/examples/texturewood.rs
@@ -18,12 +18,12 @@ fn main() {
     let scaled_base_wood_grain = ScalePoint::new(wood_grain_noise).set_z_scale(0.25);
 
     // Scale the wood-grain values so that they can be added to the base wood texture.
-    let wood_grain = ScaleBias::new(&scaled_base_wood_grain)
+    let wood_grain = ScaleBias::new(scaled_base_wood_grain)
         .set_scale(0.25)
         .set_bias(0.125);
 
     // Add the wood grain texture to the base wood texture.
-    let combined_wood = Add::new(&base_wood, &wood_grain);
+    let combined_wood = Add::new(base_wood, wood_grain);
 
     // Slightly perturb the wood to create a more realistic texture.
     let perturbed_wood = Turbulence::new(combined_wood)
@@ -45,7 +45,7 @@ fn main() {
         .set_power(1.0 / 64.0)
         .set_roughness(4);
 
-    let planar_texture = PlaneMapBuilder::new(&final_wood)
+    let planar_texture = PlaneMapBuilder::new(final_wood)
         .set_size(1024, 1024)
         .build();
 

--- a/examples/translate_point.rs
+++ b/examples/translate_point.rs
@@ -6,7 +6,7 @@ fn main() {
     let cboard = Checkerboard::default();
     let translate_point = TranslatePoint::new(cboard).set_all_translations(0.5, 0.5, 0.0, 0.0);
 
-    PlaneMapBuilder::new(&translate_point)
+    PlaneMapBuilder::new(translate_point)
         .build()
         .write_to_file("translate_point.png");
 }

--- a/examples/turbulence.rs
+++ b/examples/turbulence.rs
@@ -4,9 +4,9 @@ use noise::{utils::*, Perlin, Turbulence};
 
 fn main() {
     let perlin = Perlin::default();
-    let turbulence = Turbulence::new(&perlin);
+    let turbulence = Turbulence::new(perlin);
 
-    PlaneMapBuilder::new(&turbulence)
+    PlaneMapBuilder::new(turbulence)
         .build()
         .write_to_file("turbulence.png");
 }

--- a/examples/value.rs
+++ b/examples/value.rs
@@ -5,7 +5,7 @@ extern crate noise;
 use noise::{utils::*, Value};
 
 fn main() {
-    PlaneMapBuilder::new(&Value::default())
+    PlaneMapBuilder::new(Value::default())
         .build()
         .write_to_file("value.png");
 }

--- a/examples/worley.rs
+++ b/examples/worley.rs
@@ -7,40 +7,44 @@ use noise::{
 };
 
 fn main() {
-    PlaneMapBuilder::new(&Worley::default())
+    PlaneMapBuilder::new(Worley::default())
         .build()
         .write_to_file("worley.png");
 
-    PlaneMapBuilder::new(&Worley::default().set_return_type(ReturnType::Distance))
+    PlaneMapBuilder::new(Worley::default().set_return_type(ReturnType::Distance))
         .build()
         .write_to_file("worley_distance.png");
 
-    PlaneMapBuilder::new(&Worley::default().set_distance_function(euclidean_squared))
+    PlaneMapBuilder::new(Worley::default().set_distance_function(euclidean_squared))
         .build()
         .write_to_file("worley_squared.png");
 
     PlaneMapBuilder::new(
-        &Worley::default()
+        Worley::default()
             .set_return_type(ReturnType::Distance)
             .set_distance_function(euclidean_squared),
     )
     .build()
     .write_to_file("worley_squared_distance.png");
 
-    PlaneMapBuilder::new(&Worley::default().set_distance_function(manhattan))
+    PlaneMapBuilder::new(Worley::default().set_distance_function(manhattan))
         .build()
         .write_to_file("worley_manhattan.png");
 
-    PlaneMapBuilder::new(&Worley::default().set_return_type(ReturnType::Distance))
-        .build()
-        .write_to_file("worley_manhattan_distance.png");
+    PlaneMapBuilder::new(
+        Worley::default()
+            .set_distance_function(manhattan)
+            .set_return_type(ReturnType::Distance),
+    )
+    .build()
+    .write_to_file("worley_manhattan_distance.png");
 
-    PlaneMapBuilder::new(&Worley::default().set_distance_function(chebyshev))
+    PlaneMapBuilder::new(Worley::default().set_distance_function(chebyshev))
         .build()
         .write_to_file("worley_chebyshev.png");
 
     PlaneMapBuilder::new(
-        &Worley::default()
+        Worley::default()
             .set_return_type(ReturnType::Distance)
             .set_distance_function(chebyshev),
     )

--- a/src/noise_fns.rs
+++ b/src/noise_fns.rs
@@ -1,6 +1,7 @@
 pub use self::{
     cache::*, combiners::*, generators::*, modifiers::*, selectors::*, transformers::*,
 };
+use alloc::boxed::Box;
 
 mod cache;
 mod combiners;
@@ -26,10 +27,23 @@ pub trait NoiseFn<T, const DIM: usize> {
     fn get(&self, point: [T; DIM]) -> f64;
 }
 
-impl<'a, T, M: NoiseFn<T, DIM> + ?Sized, const DIM: usize> NoiseFn<T, DIM> for &'a M {
+impl<'a, T, M, const DIM: usize> NoiseFn<T, DIM> for &'a M
+where
+    M: NoiseFn<T, DIM> + ?Sized,
+{
     #[inline]
     fn get(&self, point: [T; DIM]) -> f64 {
         M::get(*self, point)
+    }
+}
+
+impl<T, M, const DIM: usize> NoiseFn<T, DIM> for Box<M>
+where
+    M: NoiseFn<T, DIM> + ?Sized,
+{
+    #[inline]
+    fn get(&self, point: [T; DIM]) -> f64 {
+        M::get(self, point)
     }
 }
 

--- a/src/noise_fns.rs
+++ b/src/noise_fns.rs
@@ -26,7 +26,7 @@ pub trait NoiseFn<T, const DIM: usize> {
     fn get(&self, point: [T; DIM]) -> f64;
 }
 
-impl<'a, T, M: NoiseFn<T, DIM>, const DIM: usize> NoiseFn<T, DIM> for &'a M {
+impl<'a, T, M: NoiseFn<T, DIM> + ?Sized, const DIM: usize> NoiseFn<T, DIM> for &'a M {
     #[inline]
     fn get(&self, point: [T; DIM]) -> f64 {
         M::get(*self, point)

--- a/src/noise_fns/combiners/add.rs
+++ b/src/noise_fns/combiners/add.rs
@@ -1,24 +1,41 @@
 use crate::noise_fns::NoiseFn;
+use core::marker::PhantomData;
 
 /// Noise function that outputs the sum of the two output values from two source
 /// functions.
-pub struct Add<'a, T, const DIM: usize> {
+pub struct Add<T, Source1, Source2, const DIM: usize>
+where
+    Source1: NoiseFn<T, DIM>,
+    Source2: NoiseFn<T, DIM>,
+{
     /// Outputs a value.
-    pub source1: &'a dyn NoiseFn<T, DIM>,
+    pub source1: Source1,
 
     /// Outputs a value.
-    pub source2: &'a dyn NoiseFn<T, DIM>,
+    pub source2: Source2,
+
+    phantom: PhantomData<T>,
 }
 
-impl<'a, T, const DIM: usize> Add<'a, T, DIM> {
-    pub fn new(source1: &'a dyn NoiseFn<T, DIM>, source2: &'a dyn NoiseFn<T, DIM>) -> Self {
-        Self { source1, source2 }
+impl<T, Source1, Source2, const DIM: usize> Add<T, Source1, Source2, DIM>
+where
+    Source1: NoiseFn<T, DIM>,
+    Source2: NoiseFn<T, DIM>,
+{
+    pub fn new(source1: Source1, source2: Source2) -> Self {
+        Self {
+            source1,
+            source2,
+            phantom: PhantomData,
+        }
     }
 }
 
-impl<'a, T, const DIM: usize> NoiseFn<T, DIM> for Add<'a, T, DIM>
+impl<T, Source1, Source2, const DIM: usize> NoiseFn<T, DIM> for Add<T, Source1, Source2, DIM>
 where
     T: Copy,
+    Source1: NoiseFn<T, DIM>,
+    Source2: NoiseFn<T, DIM>,
 {
     fn get(&self, point: [T; DIM]) -> f64 {
         self.source1.get(point) + self.source2.get(point)

--- a/src/noise_fns/combiners/max.rs
+++ b/src/noise_fns/combiners/max.rs
@@ -1,24 +1,41 @@
 use crate::noise_fns::NoiseFn;
+use core::marker::PhantomData;
 
 /// Noise function that outputs the larger of the two output values from two source
 /// functions.
-pub struct Max<'a, T, const DIM: usize> {
+pub struct Max<T, Source1, Source2, const DIM: usize>
+where
+    Source1: NoiseFn<T, DIM>,
+    Source2: NoiseFn<T, DIM>,
+{
     /// Outputs a value.
-    pub source1: &'a dyn NoiseFn<T, DIM>,
+    pub source1: Source1,
 
     /// Outputs a value.
-    pub source2: &'a dyn NoiseFn<T, DIM>,
+    pub source2: Source2,
+
+    phantom: PhantomData<T>,
 }
 
-impl<'a, T, const DIM: usize> Max<'a, T, DIM> {
-    pub fn new(source1: &'a dyn NoiseFn<T, DIM>, source2: &'a dyn NoiseFn<T, DIM>) -> Self {
-        Self { source1, source2 }
+impl<T, Source1, Source2, const DIM: usize> Max<T, Source1, Source2, DIM>
+where
+    Source1: NoiseFn<T, DIM>,
+    Source2: NoiseFn<T, DIM>,
+{
+    pub fn new(source1: Source1, source2: Source2) -> Self {
+        Self {
+            source1,
+            source2,
+            phantom: PhantomData,
+        }
     }
 }
 
-impl<'a, T, const DIM: usize> NoiseFn<T, DIM> for Max<'a, T, DIM>
+impl<T, Source1, Source2, const DIM: usize> NoiseFn<T, DIM> for Max<T, Source1, Source2, DIM>
 where
     T: Copy,
+    Source1: NoiseFn<T, DIM>,
+    Source2: NoiseFn<T, DIM>,
 {
     fn get(&self, point: [T; DIM]) -> f64 {
         (self.source1.get(point)).max(self.source2.get(point))

--- a/src/noise_fns/combiners/min.rs
+++ b/src/noise_fns/combiners/min.rs
@@ -1,24 +1,41 @@
 use crate::noise_fns::NoiseFn;
+use core::marker::PhantomData;
 
 /// Noise function that outputs the smaller of the two output values from two source
 /// functions.
-pub struct Min<'a, T, const DIM: usize> {
+pub struct Min<T, Source1, Source2, const DIM: usize>
+where
+    Source1: NoiseFn<T, DIM>,
+    Source2: NoiseFn<T, DIM>,
+{
     /// Outputs a value.
-    pub source1: &'a dyn NoiseFn<T, DIM>,
+    pub source1: Source1,
 
     /// Outputs a value.
-    pub source2: &'a dyn NoiseFn<T, DIM>,
+    pub source2: Source2,
+
+    phantom: PhantomData<T>,
 }
 
-impl<'a, T, const DIM: usize> Min<'a, T, DIM> {
-    pub fn new(source1: &'a dyn NoiseFn<T, DIM>, source2: &'a dyn NoiseFn<T, DIM>) -> Self {
-        Self { source1, source2 }
+impl<T, Source1, Source2, const DIM: usize> Min<T, Source1, Source2, DIM>
+where
+    Source1: NoiseFn<T, DIM>,
+    Source2: NoiseFn<T, DIM>,
+{
+    pub fn new(source1: Source1, source2: Source2) -> Self {
+        Self {
+            source1,
+            source2,
+            phantom: PhantomData,
+        }
     }
 }
 
-impl<'a, T, const DIM: usize> NoiseFn<T, DIM> for Min<'a, T, DIM>
+impl<T, Source1, Source2, const DIM: usize> NoiseFn<T, DIM> for Min<T, Source1, Source2, DIM>
 where
     T: Copy,
+    Source1: NoiseFn<T, DIM>,
+    Source2: NoiseFn<T, DIM>,
 {
     fn get(&self, point: [T; DIM]) -> f64 {
         (self.source1.get(point)).min(self.source2.get(point))

--- a/src/noise_fns/combiners/multiply.rs
+++ b/src/noise_fns/combiners/multiply.rs
@@ -1,24 +1,41 @@
 use crate::noise_fns::NoiseFn;
+use core::marker::PhantomData;
 
 /// Noise function that outputs the product of the two output values from two source
 /// functions.
-pub struct Multiply<'a, T, const DIM: usize> {
+pub struct Multiply<T, Source1, Source2, const DIM: usize>
+where
+    Source1: NoiseFn<T, DIM>,
+    Source2: NoiseFn<T, DIM>,
+{
     /// Outputs a value.
-    pub source1: &'a dyn NoiseFn<T, DIM>,
+    pub source1: Source1,
 
     /// Outputs a value.
-    pub source2: &'a dyn NoiseFn<T, DIM>,
+    pub source2: Source2,
+
+    phantom: PhantomData<T>,
 }
 
-impl<'a, T, const DIM: usize> Multiply<'a, T, DIM> {
-    pub fn new(source1: &'a dyn NoiseFn<T, DIM>, source2: &'a dyn NoiseFn<T, DIM>) -> Self {
-        Self { source1, source2 }
+impl<T, Source1, Source2, const DIM: usize> Multiply<T, Source1, Source2, DIM>
+where
+    Source1: NoiseFn<T, DIM>,
+    Source2: NoiseFn<T, DIM>,
+{
+    pub fn new(source1: Source1, source2: Source2) -> Self {
+        Self {
+            source1,
+            source2,
+            phantom: PhantomData,
+        }
     }
 }
 
-impl<'a, T, const DIM: usize> NoiseFn<T, DIM> for Multiply<'a, T, DIM>
+impl<T, Source1, Source2, const DIM: usize> NoiseFn<T, DIM> for Multiply<T, Source1, Source2, DIM>
 where
     T: Copy,
+    Source1: NoiseFn<T, DIM>,
+    Source2: NoiseFn<T, DIM>,
 {
     fn get(&self, point: [T; DIM]) -> f64 {
         self.source1.get(point) * self.source2.get(point)

--- a/src/noise_fns/combiners/power.rs
+++ b/src/noise_fns/combiners/power.rs
@@ -1,24 +1,41 @@
 use crate::noise_fns::NoiseFn;
+use core::marker::PhantomData;
 
 /// Noise function that raises the output value from the first source function
 /// to the power of the output value of the second source function.
-pub struct Power<'a, T, const DIM: usize> {
+pub struct Power<T, Source1, Source2, const DIM: usize>
+where
+    Source1: NoiseFn<T, DIM>,
+    Source2: NoiseFn<T, DIM>,
+{
     /// Outputs a value.
-    pub source1: &'a dyn NoiseFn<T, DIM>,
+    pub source1: Source1,
 
     /// Outputs a value.
-    pub source2: &'a dyn NoiseFn<T, DIM>,
+    pub source2: Source2,
+
+    phantom: PhantomData<T>,
 }
 
-impl<'a, T, const DIM: usize> Power<'a, T, DIM> {
-    pub fn new(source1: &'a dyn NoiseFn<T, DIM>, source2: &'a dyn NoiseFn<T, DIM>) -> Self {
-        Self { source1, source2 }
+impl<T, Source1, Source2, const DIM: usize> Power<T, Source1, Source2, DIM>
+where
+    Source1: NoiseFn<T, DIM>,
+    Source2: NoiseFn<T, DIM>,
+{
+    pub fn new(source1: Source1, source2: Source2) -> Self {
+        Self {
+            source1,
+            source2,
+            phantom: PhantomData,
+        }
     }
 }
 
-impl<'a, T, const DIM: usize> NoiseFn<T, DIM> for Power<'a, T, DIM>
+impl<T, Source1, Source2, const DIM: usize> NoiseFn<T, DIM> for Power<T, Source1, Source2, DIM>
 where
     T: Copy,
+    Source1: NoiseFn<T, DIM>,
+    Source2: NoiseFn<T, DIM>,
 {
     fn get(&self, point: [T; DIM]) -> f64 {
         (self.source1.get(point)).powf(self.source2.get(point))

--- a/src/noise_fns/modifiers/abs.rs
+++ b/src/noise_fns/modifiers/abs.rs
@@ -1,19 +1,34 @@
 use crate::noise_fns::NoiseFn;
+use core::marker::PhantomData;
 
 /// Noise function that outputs the absolute value of the output value from the
 /// source function.
-pub struct Abs<'a, T, const DIM: usize> {
+pub struct Abs<T, Source, const DIM: usize>
+where
+    Source: NoiseFn<T, DIM>,
+{
     /// Outputs a value.
-    pub source: &'a dyn NoiseFn<T, DIM>,
+    pub source: Source,
+
+    phantom: PhantomData<T>,
 }
 
-impl<'a, T, const DIM: usize> Abs<'a, T, DIM> {
-    pub fn new(source: &'a dyn NoiseFn<T, DIM>) -> Self {
-        Self { source }
+impl<T, Source, const DIM: usize> Abs<T, Source, DIM>
+where
+    Source: NoiseFn<T, DIM>,
+{
+    pub fn new(source: Source) -> Self {
+        Self {
+            source,
+            phantom: PhantomData,
+        }
     }
 }
 
-impl<'a, T, const DIM: usize> NoiseFn<T, DIM> for Abs<'a, T, DIM> {
+impl<T, Source, const DIM: usize> NoiseFn<T, DIM> for Abs<T, Source, DIM>
+where
+    Source: NoiseFn<T, DIM>,
+{
     fn get(&self, point: [T; DIM]) -> f64 {
         (self.source.get(point)).abs()
     }

--- a/src/noise_fns/modifiers/clamp.rs
+++ b/src/noise_fns/modifiers/clamp.rs
@@ -1,20 +1,30 @@
 use crate::noise_fns::NoiseFn;
+use core::marker::PhantomData;
 
 /// Noise function that clamps the output value from the source function to a
 /// range of values.
-pub struct Clamp<'a, T, const DIM: usize> {
+pub struct Clamp<T, Source, const DIM: usize>
+where
+    Source: NoiseFn<T, DIM>,
+{
     /// Outputs a value.
-    pub source: &'a dyn NoiseFn<T, DIM>,
+    pub source: Source,
 
     /// Bound of the clamping range. Default is -1.0 to 1.0.
     pub bounds: (f64, f64),
+
+    phantom: PhantomData<T>,
 }
 
-impl<'a, T, const DIM: usize> Clamp<'a, T, DIM> {
-    pub fn new(source: &'a dyn NoiseFn<T, DIM>) -> Self {
+impl<T, Source, const DIM: usize> Clamp<T, Source, DIM>
+where
+    Source: NoiseFn<T, DIM>,
+{
+    pub fn new(source: Source) -> Self {
         Self {
             source,
             bounds: (-1.0, 1.0),
+            phantom: PhantomData,
         }
     }
 
@@ -40,7 +50,10 @@ impl<'a, T, const DIM: usize> Clamp<'a, T, DIM> {
     }
 }
 
-impl<'a, T, const DIM: usize> NoiseFn<T, DIM> for Clamp<'a, T, DIM> {
+impl<T, Source, const DIM: usize> NoiseFn<T, DIM> for Clamp<T, Source, DIM>
+where
+    Source: NoiseFn<T, DIM>,
+{
     fn get(&self, point: [T; DIM]) -> f64 {
         let value = self.source.get(point);
 

--- a/src/noise_fns/modifiers/exponent.rs
+++ b/src/noise_fns/modifiers/exponent.rs
@@ -1,4 +1,5 @@
 use crate::{math::scale_shift, noise_fns::NoiseFn};
+use core::marker::PhantomData;
 
 /// Noise function that maps the output value from the source function onto an
 /// exponential curve.
@@ -7,20 +8,29 @@ use crate::{math::scale_shift, noise_fns::NoiseFn};
 /// this noise function first normalizes the output value (the range becomes 0.0
 /// to 1.0), maps that value onto an exponential curve, then rescales that
 /// value back to the original range.
-pub struct Exponent<'a, T, const DIM: usize> {
+pub struct Exponent<T, Source, const DIM: usize>
+where
+    Source: NoiseFn<T, DIM>,
+{
     /// Outputs a value.
-    pub source: &'a dyn NoiseFn<T, DIM>,
+    pub source: Source,
 
     /// Exponent to apply to the output value from the source function. Default
     /// is 1.0.
     pub exponent: f64,
+
+    phantom: PhantomData<T>,
 }
 
-impl<'a, T, const DIM: usize> Exponent<'a, T, DIM> {
-    pub fn new(source: &'a dyn NoiseFn<T, DIM>) -> Self {
+impl<T, Source, const DIM: usize> Exponent<T, Source, DIM>
+where
+    Source: NoiseFn<T, DIM>,
+{
+    pub fn new(source: Source) -> Self {
         Self {
             source,
             exponent: 1.0,
+            phantom: PhantomData,
         }
     }
 
@@ -29,7 +39,10 @@ impl<'a, T, const DIM: usize> Exponent<'a, T, DIM> {
     }
 }
 
-impl<'a, T, const DIM: usize> NoiseFn<T, DIM> for Exponent<'a, T, DIM> {
+impl<T, Source, const DIM: usize> NoiseFn<T, DIM> for Exponent<T, Source, DIM>
+where
+    Source: NoiseFn<T, DIM>,
+{
     fn get(&self, point: [T; DIM]) -> f64 {
         let mut value = self.source.get(point);
         value = (value + 1.0) / 2.0;

--- a/src/noise_fns/modifiers/negate.rs
+++ b/src/noise_fns/modifiers/negate.rs
@@ -1,18 +1,33 @@
 use crate::noise_fns::NoiseFn;
+use core::marker::PhantomData;
 
 /// Noise function that negates the output value from the source function.
-pub struct Negate<'a, T, const DIM: usize> {
+pub struct Negate<T, Source, const DIM: usize>
+where
+    Source: NoiseFn<T, DIM>,
+{
     /// Outputs a value.
-    pub source: &'a dyn NoiseFn<T, DIM>,
+    pub source: Source,
+
+    phantom: PhantomData<T>,
 }
 
-impl<'a, T, const DIM: usize> Negate<'a, T, DIM> {
-    pub fn new(source: &'a dyn NoiseFn<T, DIM>) -> Self {
-        Negate { source }
+impl<T, Source, const DIM: usize> Negate<T, Source, DIM>
+where
+    Source: NoiseFn<T, DIM>,
+{
+    pub fn new(source: Source) -> Self {
+        Negate {
+            source,
+            phantom: PhantomData,
+        }
     }
 }
 
-impl<'a, T, const DIM: usize> NoiseFn<T, DIM> for Negate<'a, T, DIM> {
+impl<T, Source, const DIM: usize> NoiseFn<T, DIM> for Negate<T, Source, DIM>
+where
+    Source: NoiseFn<T, DIM>,
+{
     fn get(&self, point: [T; DIM]) -> f64 {
         -self.source.get(point)
     }

--- a/src/noise_fns/modifiers/scale_bias.rs
+++ b/src/noise_fns/modifiers/scale_bias.rs
@@ -1,13 +1,14 @@
 use crate::noise_fns::NoiseFn;
+use core::marker::PhantomData;
 
 /// Noise function that applies a scaling factor and a bias to the output value
 /// from the source function.
 ///
 /// The function retrieves the output value from the source function, multiplies
 /// it with the scaling factor, adds the bias to it, then outputs the value.
-pub struct ScaleBias<'a, T, const DIM: usize> {
+pub struct ScaleBias<T, Source, const DIM: usize> {
     /// Outputs a value.
-    pub source: &'a dyn NoiseFn<T, DIM>,
+    pub source: Source,
 
     /// Scaling factor to apply to the output value from the source function.
     /// The default value is 1.0.
@@ -16,14 +17,20 @@ pub struct ScaleBias<'a, T, const DIM: usize> {
     /// Bias to apply to the scaled output value from the source function.
     /// The default value is 0.0.
     pub bias: f64,
+
+    phantom: PhantomData<T>,
 }
 
-impl<'a, T, const DIM: usize> ScaleBias<'a, T, DIM> {
-    pub fn new(source: &'a dyn NoiseFn<T, DIM>) -> Self {
+impl<T, Source, const DIM: usize> ScaleBias<T, Source, DIM>
+where
+    Source: NoiseFn<T, DIM>,
+{
+    pub fn new(source: Source) -> Self {
         Self {
             source,
             scale: 1.0,
             bias: 0.0,
+            phantom: PhantomData,
         }
     }
 
@@ -36,7 +43,10 @@ impl<'a, T, const DIM: usize> ScaleBias<'a, T, DIM> {
     }
 }
 
-impl<'a, T, const DIM: usize> NoiseFn<T, DIM> for ScaleBias<'a, T, DIM> {
+impl<T, Source, const DIM: usize> NoiseFn<T, DIM> for ScaleBias<T, Source, DIM>
+where
+    Source: NoiseFn<T, DIM>,
+{
     #[cfg(not(target_os = "emscripten"))]
     fn get(&self, point: [T; DIM]) -> f64 {
         (self.source.get(point)).mul_add(self.scale, self.bias)

--- a/src/noise_fns/selectors/blend.rs
+++ b/src/noise_fns/selectors/blend.rs
@@ -1,41 +1,55 @@
 use crate::{math::interpolate, noise_fns::NoiseFn};
+use core::marker::PhantomData;
 
 /// Noise function that outputs a weighted blend of the output values from two
 /// source functions given the output value supplied by a control function.
 ///
 /// This noise function uses linear interpolation to perform the blending
 /// operation.
-pub struct Blend<'a, T, const DIM: usize> {
+pub struct Blend<T, Source1, Source2, Control, const DIM: usize>
+where
+    Source1: NoiseFn<T, DIM>,
+    Source2: NoiseFn<T, DIM>,
+    Control: NoiseFn<T, DIM>,
+{
     /// Outputs one of the values to blend.
-    pub source1: &'a dyn NoiseFn<T, DIM>,
+    pub source1: Source1,
 
     /// Outputs one of the values to blend.
-    pub source2: &'a dyn NoiseFn<T, DIM>,
+    pub source2: Source2,
 
     /// Determines the weight of the blending operation. Negative values weight
     /// the blend towards the output value from the `source1` function. Positive
     /// values weight the blend towards the output value from the `source2`
     /// function.
-    pub control: &'a dyn NoiseFn<T, DIM>,
+    pub control: Control,
+
+    phantom: PhantomData<T>,
 }
 
-impl<'a, T, const DIM: usize> Blend<'a, T, DIM> {
-    pub fn new(
-        source1: &'a dyn NoiseFn<T, DIM>,
-        source2: &'a dyn NoiseFn<T, DIM>,
-        control: &'a dyn NoiseFn<T, DIM>,
-    ) -> Self {
+impl<T, Source1, Source2, Control, const DIM: usize> Blend<T, Source1, Source2, Control, DIM>
+where
+    Source1: NoiseFn<T, DIM>,
+    Source2: NoiseFn<T, DIM>,
+    Control: NoiseFn<T, DIM>,
+{
+    pub fn new(source1: Source1, source2: Source2, control: Control) -> Self {
         Blend {
             source1,
             source2,
             control,
+            phantom: PhantomData,
         }
     }
 }
 
-impl<'a, T, const DIM: usize> NoiseFn<T, DIM> for Blend<'a, T, DIM>
+impl<T, Source1, Source2, Control, const DIM: usize> NoiseFn<T, DIM>
+    for Blend<T, Source1, Source2, Control, DIM>
 where
     T: Copy,
+    Source1: NoiseFn<T, DIM>,
+    Source2: NoiseFn<T, DIM>,
+    Control: NoiseFn<T, DIM>,
 {
     fn get(&self, point: [T; DIM]) -> f64 {
         let lower = self.source1.get(point);

--- a/src/utils/noise_map_builder.rs
+++ b/src/utils/noise_map_builder.rs
@@ -1,24 +1,30 @@
 use crate::{math::interpolate, noise_fns::NoiseFn, utils::noise_map::NoiseMap};
 
-pub trait NoiseMapBuilder<'a> {
+pub trait NoiseMapBuilder<SourceModule> {
     fn set_size(self, width: usize, height: usize) -> Self;
 
-    fn set_source_module(self, source_module: &'a dyn NoiseFn<f64, 3>) -> Self;
+    fn set_source_module(self, source_module: SourceModule) -> Self;
 
     fn size(&self) -> (usize, usize);
 
     fn build(&self) -> NoiseMap;
 }
 
-pub struct CylinderMapBuilder<'a> {
+pub struct CylinderMapBuilder<SourceModule>
+where
+    SourceModule: NoiseFn<f64, 3>,
+{
     angle_bounds: (f64, f64),
     height_bounds: (f64, f64),
     size: (usize, usize),
-    source_module: &'a dyn NoiseFn<f64, 3>,
+    source_module: SourceModule,
 }
 
-impl<'a> CylinderMapBuilder<'a> {
-    pub fn new(source_module: &'a dyn NoiseFn<f64, 3>) -> Self {
+impl<SourceModule> CylinderMapBuilder<SourceModule>
+where
+    SourceModule: NoiseFn<f64, 3>,
+{
+    pub fn new(source_module: SourceModule) -> Self {
         CylinderMapBuilder {
             angle_bounds: (-90.0, 90.0),
             height_bounds: (-1.0, 1.0),
@@ -70,7 +76,10 @@ impl<'a> CylinderMapBuilder<'a> {
     }
 }
 
-impl<'a> NoiseMapBuilder<'a> for CylinderMapBuilder<'a> {
+impl<SourceModule> NoiseMapBuilder<SourceModule> for CylinderMapBuilder<SourceModule>
+where
+    SourceModule: NoiseFn<f64, 3>,
+{
     fn set_size(self, width: usize, height: usize) -> Self {
         CylinderMapBuilder {
             size: (width, height),
@@ -78,7 +87,7 @@ impl<'a> NoiseMapBuilder<'a> for CylinderMapBuilder<'a> {
         }
     }
 
-    fn set_source_module(self, source_module: &'a dyn NoiseFn<f64, 3>) -> Self {
+    fn set_source_module(self, source_module: SourceModule) -> Self {
         CylinderMapBuilder {
             source_module,
             ..self
@@ -124,16 +133,22 @@ impl<'a> NoiseMapBuilder<'a> for CylinderMapBuilder<'a> {
     }
 }
 
-pub struct PlaneMapBuilder<'a> {
+pub struct PlaneMapBuilder<SourceModule>
+where
+    SourceModule: NoiseFn<f64, 3>,
+{
     is_seamless: bool,
     x_bounds: (f64, f64),
     y_bounds: (f64, f64),
     size: (usize, usize),
-    source_module: &'a dyn NoiseFn<f64, 3>,
+    source_module: SourceModule,
 }
 
-impl<'a> PlaneMapBuilder<'a> {
-    pub fn new(source_module: &'a dyn NoiseFn<f64, 3>) -> Self {
+impl<SourceModule> PlaneMapBuilder<SourceModule>
+where
+    SourceModule: NoiseFn<f64, 3>,
+{
+    pub fn new(source_module: SourceModule) -> Self {
         PlaneMapBuilder {
             is_seamless: false,
             x_bounds: (-1.0, 1.0),
@@ -173,7 +188,10 @@ impl<'a> PlaneMapBuilder<'a> {
     }
 }
 
-impl<'a> NoiseMapBuilder<'a> for PlaneMapBuilder<'a> {
+impl<SourceModule> NoiseMapBuilder<SourceModule> for PlaneMapBuilder<SourceModule>
+where
+    SourceModule: NoiseFn<f64, 3>,
+{
     fn set_size(self, width: usize, height: usize) -> Self {
         PlaneMapBuilder {
             size: (width, height),
@@ -181,7 +199,7 @@ impl<'a> NoiseMapBuilder<'a> for PlaneMapBuilder<'a> {
         }
     }
 
-    fn set_source_module(self, source_module: &'a dyn NoiseFn<f64, 3>) -> Self {
+    fn set_source_module(self, source_module: SourceModule) -> Self {
         PlaneMapBuilder {
             source_module,
             ..self
@@ -240,15 +258,21 @@ impl<'a> NoiseMapBuilder<'a> for PlaneMapBuilder<'a> {
     }
 }
 
-pub struct SphereMapBuilder<'a> {
+pub struct SphereMapBuilder<SourceModule>
+where
+    SourceModule: NoiseFn<f64, 3>,
+{
     latitude_bounds: (f64, f64),
     longitude_bounds: (f64, f64),
     size: (usize, usize),
-    source_module: &'a dyn NoiseFn<f64, 3>,
+    source_module: SourceModule,
 }
 
-impl<'a> SphereMapBuilder<'a> {
-    pub fn new(source_module: &'a dyn NoiseFn<f64, 3>) -> Self {
+impl<SourceModule> SphereMapBuilder<SourceModule>
+where
+    SourceModule: NoiseFn<f64, 3>,
+{
+    pub fn new(source_module: SourceModule) -> Self {
         SphereMapBuilder {
             latitude_bounds: (-1.0, 1.0),
             longitude_bounds: (-1.0, 1.0),
@@ -294,7 +318,10 @@ impl<'a> SphereMapBuilder<'a> {
     }
 }
 
-impl<'a> NoiseMapBuilder<'a> for SphereMapBuilder<'a> {
+impl<SourceModule> NoiseMapBuilder<SourceModule> for SphereMapBuilder<SourceModule>
+where
+    SourceModule: NoiseFn<f64, 3>,
+{
     fn set_size(self, width: usize, height: usize) -> Self {
         SphereMapBuilder {
             size: (width, height),
@@ -302,7 +329,7 @@ impl<'a> NoiseMapBuilder<'a> for SphereMapBuilder<'a> {
         }
     }
 
-    fn set_source_module(self, source_module: &'a dyn NoiseFn<f64, 3>) -> Self {
+    fn set_source_module(self, source_module: SourceModule) -> Self {
         SphereMapBuilder {
             source_module,
             ..self


### PR DESCRIPTION
Per some discussion, it was strongly recommended to revert back to using generics instead of `dyn NoiseFn` due to it being more flexible for users of the library.