### PR TITLE
Fix bug in checkerboard

### DIFF
--- a/src/noise_fns/generators/checkerboard.rs
+++ b/src/noise_fns/generators/checkerboard.rs
@@ -43,8 +43,9 @@ impl<const N: usize> NoiseFn<f64, N> for Checkerboard {
     fn get(&self, point: [f64; N]) -> f64 {
         let result = point
             .iter()
-            .map(|&a| a.floor() as usize)
-            .fold(0, |a, b| (a & self.size) ^ (b & self.size));
+            .map(|&a| a.floor() as isize)
+            .reduce(|a, b| (a & self.size as isize) ^ (b & self.size as isize))
+            .unwrap();
 
         if result > 0 {
             -1.0


### PR DESCRIPTION
Checkerboard wasn't making an actual checkerboard pattern due to the casting to `usize` when flooring. Casting to `isize` instead makes things work properly.