### PR TITLE
Change Octaves to be u8 instead of usize

### DIFF
--- a/src/noise_fns/generators/fractals.rs
+++ b/src/noise_fns/generators/fractals.rs
@@ -11,7 +11,7 @@ use crate::Seedable;
 
 /// Trait for `MultiFractal` functions
 pub trait MultiFractal {
-    fn set_octaves(self, octaves: usize) -> Self;
+    fn set_octaves(self, octaves: u8) -> Self;
 
     fn set_frequency(self, frequency: f64) -> Self;
 
@@ -20,11 +20,11 @@ pub trait MultiFractal {
     fn set_persistence(self, persistence: f64) -> Self;
 }
 
-fn build_sources<Source>(seed: u32, octaves: usize) -> Vec<Source>
+fn build_sources<Source>(seed: u32, octaves: u8) -> Vec<Source>
 where
     Source: Default + Seedable,
 {
-    let mut sources = Vec::with_capacity(octaves);
+    let mut sources = Vec::with_capacity(octaves as usize);
     for x in 0..octaves {
         let source = Source::default();
         sources.push(source.set_seed(seed + x as u32));

--- a/src/noise_fns/generators/fractals/basicmulti.rs
+++ b/src/noise_fns/generators/fractals/basicmulti.rs
@@ -21,7 +21,7 @@ pub struct BasicMulti {
     /// The number of octaves control the _amount of detail_ in the noise
     /// function. Adding more octaves increases the detail, with the drawback
     /// of increasing the calculation time.
-    pub octaves: usize,
+    pub octaves: u8,
 
     /// The number of cycles per unit length that the noise function outputs.
     pub frequency: f64,
@@ -50,7 +50,7 @@ pub struct BasicMulti {
 
 impl BasicMulti {
     pub const DEFAULT_SEED: u32 = 0;
-    pub const DEFAULT_OCTAVES: usize = 6;
+    pub const DEFAULT_OCTAVES: u8 = 6;
     pub const DEFAULT_FREQUENCY: f64 = 2.0;
     pub const DEFAULT_LACUNARITY: f64 = core::f64::consts::PI * 2.0 / 3.0;
     pub const DEFAULT_PERSISTENCE: f64 = 0.5;
@@ -75,12 +75,11 @@ impl Default for BasicMulti {
 }
 
 impl MultiFractal for BasicMulti {
-    fn set_octaves(self, mut octaves: usize) -> Self {
+    fn set_octaves(self, octaves: u8) -> Self {
         if self.octaves == octaves {
             return self;
         }
 
-        octaves = octaves.clamp(1, Self::MAX_OCTAVES);
         Self {
             octaves,
             sources: super::build_sources(self.seed, octaves),
@@ -132,7 +131,7 @@ impl NoiseFn<f64, 2> for BasicMulti {
         let mut result = self.sources[0].get(point.into_array());
 
         // Spectral construction inner loop, where the fractal is built.
-        for x in 1..self.octaves {
+        for x in 1..self.octaves as usize {
             // Raise the spatial frequency.
             point *= self.lacunarity;
 
@@ -164,7 +163,7 @@ impl NoiseFn<f64, 3> for BasicMulti {
         let mut result = self.sources[0].get(point.into_array());
 
         // Spectral construction inner loop, where the fractal is built.
-        for x in 1..self.octaves {
+        for x in 1..self.octaves as usize {
             // Raise the spatial frequency.
             point *= self.lacunarity;
 
@@ -196,7 +195,7 @@ impl NoiseFn<f64, 4> for BasicMulti {
         let mut result = self.sources[0].get(point.into_array());
 
         // Spectral construction inner loop, where the fractal is built.
-        for x in 1..self.octaves {
+        for x in 1..self.octaves as usize {
             // Raise the spatial frequency.
             point *= self.lacunarity;
 

--- a/src/noise_fns/generators/fractals/billow.rs
+++ b/src/noise_fns/generators/fractals/billow.rs
@@ -18,7 +18,7 @@ pub struct Billow {
     /// The number of octaves control the _amount of detail_ in the noise
     /// function. Adding more octaves increases the detail, with the drawback
     /// of increasing the calculation time.
-    pub octaves: usize,
+    pub octaves: u8,
 
     /// The number of cycles per unit length that the noise function outputs.
     pub frequency: f64,
@@ -46,13 +46,13 @@ pub struct Billow {
     scale_factor: f64,
 }
 
-fn calc_scale_factor(persistence: f64, octaves: usize) -> f64 {
+fn calc_scale_factor(persistence: f64, octaves: u8) -> f64 {
     1.0 - persistence.powi(octaves as i32)
 }
 
 impl Billow {
     pub const DEFAULT_SEED: u32 = 0;
-    pub const DEFAULT_OCTAVE_COUNT: usize = 6;
+    pub const DEFAULT_OCTAVE_COUNT: u8 = 6;
     pub const DEFAULT_FREQUENCY: f64 = 1.0;
     pub const DEFAULT_LACUNARITY: f64 = core::f64::consts::PI * 2.0 / 3.0;
     pub const DEFAULT_PERSISTENCE: f64 = 0.5;
@@ -73,7 +73,7 @@ impl Billow {
         }
     }
 
-    fn calc_scale_factor(persistence: f64, octaves: usize) -> f64 {
+    fn calc_scale_factor(persistence: f64, octaves: u8) -> f64 {
         1.0 - persistence.powi(octaves as i32)
     }
 }
@@ -85,12 +85,11 @@ impl Default for Billow {
 }
 
 impl MultiFractal for Billow {
-    fn set_octaves(self, mut octaves: usize) -> Self {
+    fn set_octaves(self, octaves: u8) -> Self {
         if self.octaves == octaves {
             return self;
         }
 
-        octaves = octaves.clamp(1, Self::MAX_OCTAVES);
         Self {
             octaves,
             sources: super::build_sources(self.seed, octaves),
@@ -143,7 +142,7 @@ impl NoiseFn<f64, 2> for Billow {
 
         point *= self.frequency;
 
-        for x in 0..self.octaves {
+        for x in 0..self.octaves as usize {
             // Get the signal.
             let mut signal = self.sources[x].get(point.into_array());
 
@@ -175,7 +174,7 @@ impl NoiseFn<f64, 3> for Billow {
 
         point *= self.frequency;
 
-        for x in 0..self.octaves {
+        for x in 0..self.octaves as usize {
             // Get the signal.
             let mut signal = self.sources[x].get(point.into_array());
 
@@ -207,7 +206,7 @@ impl NoiseFn<f64, 4> for Billow {
 
         point *= self.frequency;
 
-        for x in 0..self.octaves {
+        for x in 0..self.octaves as usize {
             // Get the signal.
             let mut signal = self.sources[x].get(point.into_array());
 

--- a/src/noise_fns/generators/fractals/fbm.rs
+++ b/src/noise_fns/generators/fractals/fbm.rs
@@ -27,7 +27,7 @@ pub struct Fbm {
     /// The number of octaves control the _amount of detail_ in the noise
     /// function. Adding more octaves increases the detail, with the drawback
     /// of increasing the calculation time.
-    pub octaves: usize,
+    pub octaves: u8,
 
     /// The number of cycles per unit length that the noise function outputs.
     pub frequency: f64,
@@ -55,13 +55,13 @@ pub struct Fbm {
     scale_factor: f64,
 }
 
-fn calc_scale_factor(persistence: f64, octaves: usize) -> f64 {
+fn calc_scale_factor(persistence: f64, octaves: u8) -> f64 {
     1.0 - persistence.powi(octaves as i32)
 }
 
 impl Fbm {
     pub const DEFAULT_SEED: u32 = 0;
-    pub const DEFAULT_OCTAVE_COUNT: usize = 6;
+    pub const DEFAULT_OCTAVE_COUNT: u8 = 6;
     pub const DEFAULT_FREQUENCY: f64 = 1.0;
     pub const DEFAULT_LACUNARITY: f64 = core::f64::consts::PI * 2.0 / 3.0;
     pub const DEFAULT_PERSISTENCE: f64 = 0.5;
@@ -82,7 +82,7 @@ impl Fbm {
         }
     }
 
-    fn calc_scale_factor(persistence: f64, octaves: usize) -> f64 {
+    fn calc_scale_factor(persistence: f64, octaves: u8) -> f64 {
         1.0 - persistence.powi(octaves as i32)
     }
 }
@@ -94,12 +94,11 @@ impl Default for Fbm {
 }
 
 impl MultiFractal for Fbm {
-    fn set_octaves(self, mut octaves: usize) -> Self {
+    fn set_octaves(self, octaves: u8) -> Self {
         if self.octaves == octaves {
             return self;
         }
 
-        octaves = octaves.clamp(1, Self::MAX_OCTAVES);
         Self {
             octaves,
             sources: super::build_sources(self.seed, octaves),
@@ -152,7 +151,7 @@ impl NoiseFn<f64, 2> for Fbm {
 
         point *= self.frequency;
 
-        for x in 0..self.octaves {
+        for x in 0..self.octaves as usize {
             // Get the signal.
             let mut signal = self.sources[x].get(point.into_array());
 
@@ -180,7 +179,7 @@ impl NoiseFn<f64, 3> for Fbm {
 
         point *= self.frequency;
 
-        for x in 0..self.octaves {
+        for x in 0..self.octaves as usize {
             // Get the signal.
             let mut signal = self.sources[x].get(point.into_array());
 
@@ -208,7 +207,7 @@ impl NoiseFn<f64, 4> for Fbm {
 
         point *= self.frequency;
 
-        for x in 0..self.octaves {
+        for x in 0..self.octaves as usize {
             // Get the signal.
             let mut signal = self.sources[x].get(point.into_array());
 

--- a/src/noise_fns/generators/fractals/hybridmulti.rs
+++ b/src/noise_fns/generators/fractals/hybridmulti.rs
@@ -15,7 +15,7 @@ pub struct HybridMulti {
     /// The number of octaves control the _amount of detail_ in the noise
     /// function. Adding more octaves increases the detail, with the drawback
     /// of increasing the calculation time.
-    pub octaves: usize,
+    pub octaves: u8,
 
     /// The number of cycles per unit length that the noise function outputs.
     pub frequency: f64,
@@ -44,7 +44,7 @@ pub struct HybridMulti {
 
 impl HybridMulti {
     pub const DEFAULT_SEED: u32 = 0;
-    pub const DEFAULT_OCTAVES: usize = 6;
+    pub const DEFAULT_OCTAVES: u8 = 6;
     pub const DEFAULT_FREQUENCY: f64 = 2.0;
     pub const DEFAULT_LACUNARITY: f64 = core::f64::consts::PI * 2.0 / 3.0;
     pub const DEFAULT_PERSISTENCE: f64 = 0.25;
@@ -69,12 +69,11 @@ impl Default for HybridMulti {
 }
 
 impl MultiFractal for HybridMulti {
-    fn set_octaves(self, mut octaves: usize) -> Self {
+    fn set_octaves(self, octaves: u8) -> Self {
         if self.octaves == octaves {
             return self;
         }
 
-        octaves = octaves.clamp(1, Self::MAX_OCTAVES);
         Self {
             octaves,
             sources: super::build_sources(self.seed, octaves),
@@ -127,7 +126,7 @@ impl NoiseFn<f64, 2> for HybridMulti {
         let mut weight = result;
 
         // Spectral construction inner loop, where the fractal is built.
-        for x in 1..self.octaves {
+        for x in 1..self.octaves as usize {
             // Prevent divergence.
             weight = weight.max(1.0);
 
@@ -163,7 +162,7 @@ impl NoiseFn<f64, 3> for HybridMulti {
         let mut weight = result;
 
         // Spectral construction inner loop, where the fractal is built.
-        for x in 1..self.octaves {
+        for x in 1..self.octaves as usize {
             // Prevent divergence.
             weight = weight.max(1.0);
 
@@ -199,7 +198,7 @@ impl NoiseFn<f64, 4> for HybridMulti {
         let mut weight = result;
 
         // Spectral construction inner loop, where the fractal is built.
-        for x in 1..self.octaves {
+        for x in 1..self.octaves as usize {
             // Prevent divergence.
             weight = weight.max(1.0);
 

--- a/src/noise_fns/generators/fractals/ridgedmulti.rs
+++ b/src/noise_fns/generators/fractals/ridgedmulti.rs
@@ -27,7 +27,7 @@ pub struct RidgedMulti {
     /// The number of octaves control the _amount of detail_ in the noise
     /// function. Adding more octaves increases the detail, with the drawback
     /// of increasing the calculation time.
-    pub octaves: usize,
+    pub octaves: u8,
 
     /// The number of cycles per unit length that the noise function outputs.
     pub frequency: f64,
@@ -62,12 +62,11 @@ pub struct RidgedMulti {
 
 impl RidgedMulti {
     pub const DEFAULT_SEED: u32 = 0;
-    pub const DEFAULT_OCTAVE_COUNT: usize = 6;
+    pub const DEFAULT_OCTAVE_COUNT: u8 = 6;
     pub const DEFAULT_FREQUENCY: f64 = 1.0;
     pub const DEFAULT_LACUNARITY: f64 = core::f64::consts::PI * 2.0 / 3.0;
     pub const DEFAULT_PERSISTENCE: f64 = 1.0;
     pub const DEFAULT_ATTENUATION: f64 = 2.0;
-    pub const MAX_OCTAVES: usize = 32;
 
     pub fn new(seed: u32) -> Self {
         Self {
@@ -96,12 +95,11 @@ impl Default for RidgedMulti {
 }
 
 impl MultiFractal for RidgedMulti {
-    fn set_octaves(self, mut octaves: usize) -> Self {
+    fn set_octaves(self, octaves: u8) -> Self {
         if self.octaves == octaves {
             return self;
         }
 
-        octaves = octaves.clamp(1, Self::MAX_OCTAVES);
         Self {
             octaves,
             sources: super::build_sources(self.seed, octaves),
@@ -153,7 +151,7 @@ impl NoiseFn<f64, 2> for RidgedMulti {
 
         point *= self.frequency;
 
-        for x in 0..self.octaves {
+        for x in 0..self.octaves as usize {
             // Get the value.
             let mut signal = self.sources[x].get(point.into_array());
 
@@ -201,7 +199,7 @@ impl NoiseFn<f64, 3> for RidgedMulti {
 
         point *= self.frequency;
 
-        for x in 0..self.octaves {
+        for x in 0..self.octaves as usize {
             // Get the value.
             let mut signal = self.sources[x].get(point.into_array());
 
@@ -249,7 +247,7 @@ impl NoiseFn<f64, 4> for RidgedMulti {
 
         point *= self.frequency;
 
-        for x in 0..self.octaves {
+        for x in 0..self.octaves as usize {
             // Get the value.
             let mut signal = self.sources[x].get(point.into_array());
 

--- a/src/noise_fns/transformers/turbulence.rs
+++ b/src/noise_fns/transformers/turbulence.rs
@@ -13,15 +13,13 @@ pub struct Turbulence<Source> {
     /// Source function that outputs a value.
     pub source: Source,
 
-    /// Frequency value for the Turbulence function.
-    pub frequency: f64,
+    frequency: f64,
 
     /// Controls the strength of the turbulence by affecting how much each
     /// point is moved.
     pub power: f64,
 
-    /// Affects the roughness of the turbulence. Higher values are rougher.
-    pub roughness: usize,
+    roughness: u8,
 
     seed: u32,
     x_distort_function: Fbm,
@@ -34,7 +32,7 @@ impl<Source> Turbulence<Source> {
     pub const DEFAULT_SEED: u32 = 0;
     pub const DEFAULT_FREQUENCY: f64 = 1.0;
     pub const DEFAULT_POWER: f64 = 1.0;
-    pub const DEFAULT_ROUGHNESS: usize = 3;
+    pub const DEFAULT_ROUGHNESS: u8 = 3;
 
     pub fn new(source: Source) -> Self {
         Self {
@@ -62,6 +60,7 @@ impl<Source> Turbulence<Source> {
         }
     }
 
+    /// Affects the roughness of the turbulence. Higher values are rougher.
     pub fn set_frequency(self, frequency: f64) -> Self {
         Self {
             frequency,
@@ -77,7 +76,8 @@ impl<Source> Turbulence<Source> {
         Self { power, ..self }
     }
 
-    pub fn set_roughness(self, roughness: usize) -> Self {
+    /// Affects the roughness of the turbulence. Higher values are rougher.
+    pub fn set_roughness(self, roughness: u8) -> Self {
         Self {
             roughness,
             x_distort_function: self.x_distort_function.set_octaves(roughness),


### PR DESCRIPTION
u8 allows up to 256 octaves, but most of the time, the number of octaves will probably be less than 10. Don't need full pointer width to store the number of octaves, hence the move to u8.