### PR TITLE
Add a cyclic noise transformer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ std = []
 [dev-dependencies]
 criterion = "0.3"
 rand_pcg = "0.2"
+float-cmp = "0.9.0"
 
 [[bench]]
 name = "open_simplex"

--- a/src/noise_fns/transformers.rs
+++ b/src/noise_fns/transformers.rs
@@ -1,5 +1,6 @@
-pub use self::{displace::*, rotate_point::*, scale_point::*, translate_point::*, turbulence::*};
+pub use self::{cycle_point::*, displace::*, rotate_point::*, scale_point::*, translate_point::*, turbulence::*};
 
+mod cycle_point;
 mod displace;
 mod rotate_point;
 mod scale_point;

--- a/src/noise_fns/transformers/cycle_point.rs
+++ b/src/noise_fns/transformers/cycle_point.rs
@@ -1,5 +1,6 @@
 use crate::noise_fns::NoiseFn;
 
+#[inline(always)]
 fn lerp(t: f64, start: f64, end: f64) -> f64 {
     t.mul_add(end, (-t).mul_add(start, start))
 }
@@ -256,5 +257,50 @@ where
                 ),
             ),
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{super::super::Perlin, *};
+    use float_cmp::approx_eq;
+
+    #[test]
+    fn repeats_1d() {
+        let source = Perlin::default();
+        let cycle = CyclePoint::new(&source);
+        assert!(approx_eq!(f64, cycle.get([0.5, 0.]), cycle.get([1.5, 0.])));
+    }
+
+    #[test]
+    fn repeats_2d() {
+        let source = Perlin::default();
+        let cycle = CyclePoint::new(&source);
+        assert!(approx_eq!(
+            f64,
+            cycle.get([0.1, 0.1]),
+            cycle.get([1.1, 0.1])
+        ));
+        assert!(approx_eq!(
+            f64,
+            cycle.get([0.1, 0.1]),
+            cycle.get([0.1, 1.1])
+        ));
+    }
+
+    #[test]
+    fn repeats_with_period_2d() {
+        let source = Perlin::default();
+        let cycle = CyclePoint::new(&source).set_x_period(10.).set_y_period(20.);
+        assert!(approx_eq!(
+            f64,
+            cycle.get([5.1, 0.1]),
+            cycle.get([15.1, 0.1])
+        ));
+        assert!(approx_eq!(
+            f64,
+            cycle.get([5.25, 2.25]),
+            cycle.get([5.25, 22.25])
+        ));
     }
 }

--- a/src/noise_fns/transformers/cycle_point.rs
+++ b/src/noise_fns/transformers/cycle_point.rs
@@ -1,0 +1,260 @@
+use crate::noise_fns::NoiseFn;
+
+fn lerp(t: f64, start: f64, end: f64) -> f64 {
+    t.mul_add(end, (-t).mul_add(start, start))
+}
+
+/// Noise function that loops the input value over a the modulus of a domain
+/// before returning the output value from the source function.
+///
+/// The looped Noise will be continuous across the start and the end of the domain,
+/// and to accomplish this, the source function will be sampled twice and blended.
+///
+/// The domain of each dimension always starts at 0. If a different start is required,
+/// use TranslatePoint.
+///
+/// CyclePoint may be useful for repeated tiled noise, or noise around a polar domain.
+pub struct CyclePoint<Source> {
+    /// Outputs a value.
+    pub source: Source,
+
+    pub x_period: f64,
+    pub y_period: f64,
+    pub z_period: f64,
+    pub u_period: f64,
+}
+
+impl<Source> CyclePoint<Source> {
+    pub fn new(source: Source) -> Self {
+        Self {
+            source,
+            x_period: 1.,
+            y_period: 1.,
+            z_period: 1.,
+            u_period: 1.,
+        }
+    }
+
+    pub fn set_x_period(self, x_period: f64) -> Self {
+        Self { x_period, ..self }
+    }
+
+    pub fn set_y_period(self, y_period: f64) -> Self {
+        Self { y_period, ..self }
+    }
+
+    pub fn set_z_period(self, z_period: f64) -> Self {
+        Self { z_period, ..self }
+    }
+
+    pub fn set_u_period(self, u_period: f64) -> Self {
+        Self { u_period, ..self }
+    }
+}
+
+impl<Source> NoiseFn<f64, 1> for CyclePoint<Source>
+where
+    Source: NoiseFn<f64, 1>,
+{
+    fn get(&self, point: [f64; 1]) -> f64 {
+        let x0 = if point[0] >= 0. {
+            point[0] % self.x_period
+        } else {
+            (point[0] % self.x_period) + self.x_period
+        };
+        let x1 = self.x_period - x0;
+        let xt = x0 / self.x_period;
+        lerp(xt, self.source.get([x0]), self.source.get([x1]))
+    }
+}
+
+impl<Source> NoiseFn<f64, 2> for CyclePoint<Source>
+where
+    Source: NoiseFn<f64, 2>,
+{
+    fn get(&self, point: [f64; 2]) -> f64 {
+        let x0 = if point[0] >= 0. {
+            point[0] % self.x_period
+        } else {
+            (point[0] % self.x_period) + self.x_period
+        };
+        let x1 = self.x_period - x0;
+        let xt = x0 / self.x_period;
+
+        let y0 = if point[1] >= 0. {
+            point[1] % self.y_period
+        } else {
+            (point[1] % self.y_period) + self.y_period
+        };
+        let y1 = self.y_period - y0;
+        let yt = y0 / self.y_period;
+
+        lerp(
+            yt,
+            lerp(xt, self.source.get([x0, y0]), self.source.get([x1, y0])),
+            lerp(xt, self.source.get([x0, y1]), self.source.get([x1, y1])),
+        )
+    }
+}
+
+impl<Source> NoiseFn<f64, 3> for CyclePoint<Source>
+where
+    Source: NoiseFn<f64, 3>,
+{
+    fn get(&self, point: [f64; 3]) -> f64 {
+        let x0 = if point[0] >= 0. {
+            point[0] % self.x_period
+        } else {
+            (point[0] % self.x_period) + self.x_period
+        };
+        let x1 = self.x_period - x0;
+        let xt = x0 / self.x_period;
+
+        let y0 = if point[1] >= 0. {
+            point[1] % self.y_period
+        } else {
+            (point[1] % self.y_period) + self.y_period
+        };
+        let y1 = self.y_period - y0;
+        let yt = y0 / self.y_period;
+
+        let z0 = if point[2] >= 0. {
+            point[2] % self.z_period
+        } else {
+            (point[2] % self.z_period) + self.z_period
+        };
+        let z1 = self.z_period - z0;
+        let zt = z0 / self.z_period;
+
+        lerp(
+            zt,
+            lerp(
+                yt,
+                lerp(
+                    xt,
+                    self.source.get([x0, y0, z0]),
+                    self.source.get([x1, y0, z0]),
+                ),
+                lerp(
+                    xt,
+                    self.source.get([x0, y1, z0]),
+                    self.source.get([x1, y1, z0]),
+                ),
+            ),
+            lerp(
+                yt,
+                lerp(
+                    xt,
+                    self.source.get([x0, y0, z1]),
+                    self.source.get([x1, y0, z1]),
+                ),
+                lerp(
+                    xt,
+                    self.source.get([x0, y1, z1]),
+                    self.source.get([x1, y1, z1]),
+                ),
+            ),
+        )
+    }
+}
+
+impl<Source> NoiseFn<f64, 4> for CyclePoint<Source>
+where
+    Source: NoiseFn<f64, 4>,
+{
+    fn get(&self, point: [f64; 4]) -> f64 {
+        let x0 = if point[0] >= 0. {
+            point[0] % self.x_period
+        } else {
+            (point[0] % self.x_period) + self.x_period
+        };
+        let x1 = self.x_period - x0;
+        let xt = x0 / self.x_period;
+
+        let y0 = if point[1] >= 0. {
+            point[1] % self.y_period
+        } else {
+            (point[1] % self.y_period) + self.y_period
+        };
+        let y1 = self.y_period - y0;
+        let yt = y0 / self.y_period;
+
+        let z0 = if point[2] >= 0. {
+            point[2] % self.z_period
+        } else {
+            (point[2] % self.z_period) + self.z_period
+        };
+        let z1 = self.z_period - z0;
+        let zt = z0 / self.z_period;
+
+        let u0 = if point[3] >= 0. {
+            point[3] % self.u_period
+        } else {
+            (point[3] % self.u_period) + self.u_period
+        };
+        let u1 = self.u_period - u0;
+        let ut = u0 / self.u_period;
+
+        lerp(
+            ut,
+            lerp(
+                zt,
+                lerp(
+                    yt,
+                    lerp(
+                        xt,
+                        self.source.get([x0, y0, z0, u0]),
+                        self.source.get([x1, y0, z0, u0]),
+                    ),
+                    lerp(
+                        xt,
+                        self.source.get([x0, y1, z0, u0]),
+                        self.source.get([x1, y1, z0, u0]),
+                    ),
+                ),
+                lerp(
+                    yt,
+                    lerp(
+                        xt,
+                        self.source.get([x0, y0, z1, u0]),
+                        self.source.get([x1, y0, z1, u0]),
+                    ),
+                    lerp(
+                        xt,
+                        self.source.get([x0, y1, z1, u0]),
+                        self.source.get([x1, y1, z1, u0]),
+                    ),
+                ),
+            ),
+            lerp(
+                zt,
+                lerp(
+                    yt,
+                    lerp(
+                        xt,
+                        self.source.get([x0, y0, z0, u1]),
+                        self.source.get([x1, y0, z0, u1]),
+                    ),
+                    lerp(
+                        xt,
+                        self.source.get([x0, y1, z0, u1]),
+                        self.source.get([x1, y1, z0, u1]),
+                    ),
+                ),
+                lerp(
+                    yt,
+                    lerp(
+                        xt,
+                        self.source.get([x0, y0, z1, u1]),
+                        self.source.get([x1, y0, z1, u1]),
+                    ),
+                    lerp(
+                        xt,
+                        self.source.get([x0, y1, z1, u1]),
+                        self.source.get([x1, y1, z1, u1]),
+                    ),
+                ),
+            ),
+        )
+    }
+}


### PR DESCRIPTION
This adds a transformer that will make noise cyclic/periodic/tiling. This is useful, if for example, you are applying noise around a radial domain, or you wish to create a tilable texture.

Please let me know if the naming of things is appropriate (CyclePoint copies the pattern of RotatePoint, ScalePoint, etc).