### PR TITLE
Fix the range for Perlin noise (bad scale_factor)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ std = []
 [dev-dependencies]
 criterion = "0.3"
 rand_pcg = "0.2"
+float-cmp = "0.9.0"
 
 [[bench]]
 name = "open_simplex"

--- a/src/core/perlin.rs
+++ b/src/core/perlin.rs
@@ -212,7 +212,7 @@ pub fn perlin_4d<NH>(point: [f64; 4], hasher: &NH) -> f64
 where
     NH: NoiseHasher + ?Sized,
 {
-    const SCALE_FACTOR: f64 = 2.0;
+    const SCALE_FACTOR: f64 = 2.;
 
     let point = Vector4::from(point);
 
@@ -334,8 +334,8 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
-    use float_cmp::{ApproxEq, F64Margin};
     use crate::permutationtable::PermutationTable;
+    use float_cmp::{ApproxEq, F64Margin};
 
     fn range_is_valid(min: f64, max: f64) -> bool {
         min.approx_eq(-1., F64Margin::default()) && max.approx_eq(1., F64Margin::default())
@@ -351,10 +351,15 @@ mod test {
             min = min.min(val);
             max = max.max(val);
             if range_is_valid(min, max) {
-                return
+                return;
             }
         }
-        assert!(range_is_valid(min, max), "Range should be from (-1, 1), actual: ({}, {})", min, max);
+        assert!(
+            range_is_valid(min, max),
+            "Range should be from (-1, 1), actual: ({}, {})",
+            min,
+            max
+        );
     }
 
     #[test]
@@ -367,10 +372,15 @@ mod test {
             min = min.min(val);
             max = max.max(val);
             if range_is_valid(min, max) {
-                return
+                return;
             }
         }
-        assert!(range_is_valid(min, max), "Range should be from (-1, 1), actual: ({}, {})", min, max);
+        assert!(
+            range_is_valid(min, max),
+            "Range should be from (-1, 1), actual: ({}, {})",
+            min,
+            max
+        );
     }
 
     #[test]
@@ -383,10 +393,15 @@ mod test {
             min = min.min(val);
             max = max.max(val);
             if range_is_valid(min, max) {
-                return
+                return;
             }
         }
-        assert!(range_is_valid(min, max), "Range should be from (-1, 1), actual: ({}, {})", min, max);
+        assert!(
+            range_is_valid(min, max),
+            "Range should be from (-1, 1), actual: ({}, {})",
+            min,
+            max
+        );
     }
 
     #[test]
@@ -399,9 +414,14 @@ mod test {
             min = min.min(val);
             max = max.max(val);
             if range_is_valid(min, max) {
-                return
+                return;
             }
         }
-        assert!(range_is_valid(min, max), "Range should be from (-1, 1), actual: ({}, {})", min, max);
+        assert!(
+            range_is_valid(min, max),
+            "Range should be from (-1, 1), actual: ({}, {})",
+            min,
+            max
+        );
     }
 }

--- a/src/core/perlin.rs
+++ b/src/core/perlin.rs
@@ -342,7 +342,7 @@ mod test {
     }
 
     #[test]
-    fn test_1d_scale() {
+    fn test_1d_perlin_range() {
         let mut min: f64 = 0.;
         let mut max: f64 = 0.;
         for i in 0..1000 {
@@ -363,7 +363,7 @@ mod test {
     }
 
     #[test]
-    fn test_2d_scale() {
+    fn test_2d_perlin_range() {
         let mut min: f64 = 0.;
         let mut max: f64 = 0.;
         for i in 0..1000 {
@@ -384,7 +384,7 @@ mod test {
     }
 
     #[test]
-    fn test_3d_scale() {
+    fn test_3d_perlin_range() {
         let mut min: f64 = 0.;
         let mut max: f64 = 0.;
         for i in 0..1000 {
@@ -405,12 +405,12 @@ mod test {
     }
 
     #[test]
-    fn test_4d_scale() {
+    fn test_4d_perlin_range() {
         let mut min: f64 = 0.;
         let mut max: f64 = 0.;
         for i in 0..1000 {
             let perm_table = PermutationTable::new(0);
-            let val = perlin_4d([i as f64 / 64., 0., 0., 0.], &perm_table);
+            let val = perlin_4d([i as f64 / 64., 0.1, 0.2, 0.3], &perm_table);
             min = min.min(val);
             max = max.max(val);
             if range_is_valid(min, max) {

--- a/src/core/perlin.rs
+++ b/src/core/perlin.rs
@@ -7,6 +7,69 @@ use crate::{
 };
 use core::f64;
 
+
+#[inline(always)]
+fn linear_interpolation(u: f64, g0: f64, g1: f64) -> f64 {
+    let k0 = g0;
+    let k1 = g1 - g0;
+    k0 + k1 * u
+}
+
+#[inline(always)]
+pub fn perlin_1d<NH>(point: f64, hasher: &NH) -> f64
+where
+    NH: NoiseHasher + ?Sized,
+{
+    // Unscaled range of linearly interpolated perlin noise should be (-sqrt(N)/2, sqrt(N)/2).
+    // Need to invert this value and multiply the unscaled result by the value to get a scaled
+    // range of (-1, 1).
+    //
+    // 1/(sqrt(N)/2), N=1 -> 1/2
+    const SCALE_FACTOR: f64 = 0.5;
+
+    #[inline(always)]
+    #[rustfmt::skip]
+    fn gradient_dot_v(perm: usize, point: f64) -> f64 {
+        let x = point;
+
+        match perm & 0b1 {
+            0 =>  x, // ( 1 )
+            1 => -x, // (-1 )
+            _ => unreachable!(),
+        }
+    }
+
+    let floored = point.floor();
+    let corner = floored as isize;
+    let distance = point - floored;
+
+    macro_rules! call_gradient(
+        ($x_offset:expr) => {
+            {
+                gradient_dot_v(
+                    hasher.hash(&[corner + $x_offset]),
+                    distance - $x_offset as f64
+                )
+            }
+        }
+    );
+
+    let g0 = call_gradient!(0);
+    let g1 = call_gradient!(1);
+
+    let u = distance.map_quintic();
+
+    let unscaled_result = linear_interpolation(u, g0, g1);
+
+    let scaled_result = unscaled_result * SCALE_FACTOR;
+
+    // At this point, we should be really damn close to the (-1, 1) range, but some float errors
+    // could have accumulated, so let's just clamp the results to (-1, 1) to cut off any
+    // outliers and return it.
+    scaled_result.clamp(-1.0, 1.0)
+}
+
+
 #[inline(always)]
 pub fn perlin_2d<NH>(point: [f64; 2], hasher: &NH) -> f64
 where

--- a/src/core/perlin.rs
+++ b/src/core/perlin.rs
@@ -7,7 +7,6 @@ use crate::{
 };
 use core::f64;
 
-
 #[inline(always)]
 fn linear_interpolation(u: f64, g0: f64, g1: f64) -> f64 {
     let k0 = g0;
@@ -68,7 +67,6 @@ where
     // outliers and return it.
     scaled_result.clamp(-1.0, 1.0)
 }
-
 
 #[inline(always)]
 pub fn perlin_2d<NH>(point: [f64; 2], hasher: &NH) -> f64

--- a/src/noise_fns/generators/perlin.rs
+++ b/src/noise_fns/generators/perlin.rs
@@ -4,7 +4,7 @@ use crate::{
     permutationtable::PermutationTable,
 };
 
-/// Noise function that outputs 2/3/4-dimensional Perlin noise.
+/// Noise function that outputs 1/2/3/4-dimensional Perlin noise.
 #[derive(Clone, Copy, Debug)]
 pub struct Perlin {
     seed: u32,
@@ -45,6 +45,13 @@ impl Seedable for Perlin {
 
     fn seed(&self) -> u32 {
         self.seed
+    }
+}
+
+/// 1-dimensional perlin noise
+impl NoiseFn<f64, 1> for Perlin {
+    fn get(&self, point: [f64; 1]) -> f64 {
+        perlin_1d(point[0], &self.perm_table)
     }
 }
 


### PR DESCRIPTION
Builds off branch feature/1dperlin, since I added a test for 1d perlin too.

Each SCALE_FACTORs in the code seemed to be incorrect. Unscaled, each function would return between [-0.5, 0.5]. So in each dimension the scale factor should be the same: 2. I added unit tests to support this.