### PR TITLE
Add NoiseMapBuilder import in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ See the individual function pages for their descriptions, and the [examples][exa
 
 ```rust
 use noise::Fbm;
-use noise::utils::PlaneMapBuilder;
+use noise::utils::{NoiseMapBuilder, PlaneMapBuilder};
 
 fn main() {
   let fbm = Fbm::new();


### PR DESCRIPTION
`set_size` and `build` are attached to the `NoiseMapBuilder` trait, so `NoiseMapBuilder` must be in scope for these methods to be made use of.