### PR TITLE
Fixed Simplex, OpenSimplex examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ See the individual function pages for their descriptions, and the [examples][exa
 
 ```rust
 use noise::Fbm;
-use noise::utils::PlaneMapBuilder;
+use noise::utils::{NoiseMapBuilder, PlaneMapBuilder};
 
 fn main() {
   let fbm = Fbm::new();

--- a/examples/open_simplex.rs
+++ b/examples/open_simplex.rs
@@ -7,13 +7,12 @@ use noise::{utils::*, OpenSimplex, Seedable};
 fn main() {
     let open_simplex = OpenSimplex::default();
 
-    PlaneMapBuilder::new(open_simplex)
+    (PlaneMapBuilder::new(open_simplex) as PlaneMapBuilder<OpenSimplex, 2>)
         .build()
         .write_to_file("open_simplex.png");
 
     let open_simplex = open_simplex.set_seed(1);
-
-    PlaneMapBuilder::new(open_simplex)
+    (PlaneMapBuilder::new(open_simplex) as PlaneMapBuilder<OpenSimplex, 2>)
         .build()
         .write_to_file("open_simplex_seed=1.png");
 }

--- a/examples/simplex.rs
+++ b/examples/simplex.rs
@@ -5,7 +5,7 @@ extern crate noise;
 use noise::{utils::*, Seedable, Simplex};
 
 fn main() {
-    let mut simplex = Simplex::default();
+    let simplex = Simplex::default();
 
     (PlaneMapBuilder::new(simplex) as PlaneMapBuilder<Simplex, 2>)
         .set_size(1024, 1024)
@@ -14,7 +14,7 @@ fn main() {
         .build()
         .write_to_file("simplex.png");
 
-    simplex = simplex.set_seed(1);
+    let simplex = simplex.set_seed(1);
     (PlaneMapBuilder::new(simplex) as PlaneMapBuilder<Simplex, 2>)
         .set_size(1024, 1024)
         .set_x_bounds(-5.0, 5.0)

--- a/examples/simplex.rs
+++ b/examples/simplex.rs
@@ -7,7 +7,7 @@ use noise::{utils::*, Seedable, Simplex};
 fn main() {
     let mut simplex = Simplex::default();
 
-    PlaneMapBuilder::new(simplex)
+    (PlaneMapBuilder::new(simplex) as PlaneMapBuilder<Simplex, 2>)
         .set_size(1024, 1024)
         .set_x_bounds(-5.0, 5.0)
         .set_y_bounds(-5.0, 5.0)
@@ -15,8 +15,7 @@ fn main() {
         .write_to_file("simplex.png");
 
     simplex = simplex.set_seed(1);
-
-    PlaneMapBuilder::new(simplex)
+    (PlaneMapBuilder::new(simplex) as PlaneMapBuilder<Simplex, 2>)
         .set_size(1024, 1024)
         .set_x_bounds(-5.0, 5.0)
         .set_y_bounds(-5.0, 5.0)


### PR DESCRIPTION
`cargo run --example simplex --features="images"`

Previously you encountered this error
cannot infer the value of const parameter `DIM

It was fixed with a simple cast

