### PR TITLE
Fix incorrect seeds in HybridMulti and RidgedMulti

### DIFF
--- a/src/noise_fns/generators/fractals/hybridmulti.rs
+++ b/src/noise_fns/generators/fractals/hybridmulti.rs
@@ -60,7 +60,7 @@ where
             frequency: Self::DEFAULT_FREQUENCY,
             lacunarity: Self::DEFAULT_LACUNARITY,
             persistence: Self::DEFAULT_PERSISTENCE,
-            sources: super::build_sources(Self::DEFAULT_SEED, Self::DEFAULT_OCTAVES),
+            sources: super::build_sources(seed, Self::DEFAULT_OCTAVES),
         }
     }
 

--- a/src/noise_fns/generators/fractals/ridgedmulti.rs
+++ b/src/noise_fns/generators/fractals/ridgedmulti.rs
@@ -80,7 +80,7 @@ where
             lacunarity: Self::DEFAULT_LACUNARITY,
             persistence: Self::DEFAULT_PERSISTENCE,
             attenuation: Self::DEFAULT_ATTENUATION,
-            sources: super::build_sources(Self::DEFAULT_SEED, Self::DEFAULT_OCTAVE_COUNT),
+            sources: super::build_sources(seed, Self::DEFAULT_OCTAVE_COUNT),
         }
     }
 


### PR DESCRIPTION
Fixes `HybridMulti::new()` and `RidgedMulti::new()` to use the provided seed rather than `DEFAULT_SEED`.