### PR TITLE
Fix simplex 1d gradient function

### DIFF
--- a/src/core/simplex.rs
+++ b/src/core/simplex.rs
@@ -10,7 +10,7 @@ fn grad1(hash: u8) -> f64 {
     let gx = (1 + (h & 7)) as f64; // Gradient value is one of 1.0, 2.0, ..., 8.0
     match h & 8 {
         0 => -gx,
-        1 => gx, // Make half of the gradients negative
+        8 => gx, // Make half of the gradients negative
         _ => unreachable!(),
     }
 }


### PR DESCRIPTION
Old implementation checks the 4th bit of `h` by comparing `x & 8` with 1. This result is actually either 0 or 8.