### PR TITLE
Added Clone impls for all noise functions

### DIFF
--- a/src/noise_fns/combiners/add.rs
+++ b/src/noise_fns/combiners/add.rs
@@ -3,6 +3,7 @@ use core::marker::PhantomData;
 
 /// Noise function that outputs the sum of the two output values from two source
 /// functions.
+#[derive(Clone)]
 pub struct Add<T, Source1, Source2, const DIM: usize>
 where
     Source1: NoiseFn<T, DIM>,

--- a/src/noise_fns/combiners/max.rs
+++ b/src/noise_fns/combiners/max.rs
@@ -3,6 +3,7 @@ use core::marker::PhantomData;
 
 /// Noise function that outputs the larger of the two output values from two source
 /// functions.
+#[derive(Clone)]
 pub struct Max<T, Source1, Source2, const DIM: usize>
 where
     Source1: NoiseFn<T, DIM>,

--- a/src/noise_fns/combiners/min.rs
+++ b/src/noise_fns/combiners/min.rs
@@ -3,6 +3,7 @@ use core::marker::PhantomData;
 
 /// Noise function that outputs the smaller of the two output values from two source
 /// functions.
+#[derive(Clone)]
 pub struct Min<T, Source1, Source2, const DIM: usize>
 where
     Source1: NoiseFn<T, DIM>,

--- a/src/noise_fns/combiners/multiply.rs
+++ b/src/noise_fns/combiners/multiply.rs
@@ -3,6 +3,7 @@ use core::marker::PhantomData;
 
 /// Noise function that outputs the product of the two output values from two source
 /// functions.
+#[derive(Clone)]
 pub struct Multiply<T, Source1, Source2, const DIM: usize>
 where
     Source1: NoiseFn<T, DIM>,

--- a/src/noise_fns/combiners/power.rs
+++ b/src/noise_fns/combiners/power.rs
@@ -3,6 +3,7 @@ use core::marker::PhantomData;
 
 /// Noise function that raises the output value from the first source function
 /// to the power of the output value of the second source function.
+#[derive(Clone)]
 pub struct Power<T, Source1, Source2, const DIM: usize>
 where
     Source1: NoiseFn<T, DIM>,

--- a/src/noise_fns/modifiers/abs.rs
+++ b/src/noise_fns/modifiers/abs.rs
@@ -3,6 +3,7 @@ use core::marker::PhantomData;
 
 /// Noise function that outputs the absolute value of the output value from the
 /// source function.
+#[derive(Clone)]
 pub struct Abs<T, Source, const DIM: usize>
 where
     Source: NoiseFn<T, DIM>,

--- a/src/noise_fns/modifiers/clamp.rs
+++ b/src/noise_fns/modifiers/clamp.rs
@@ -3,6 +3,7 @@ use core::marker::PhantomData;
 
 /// Noise function that clamps the output value from the source function to a
 /// range of values.
+#[derive(Clone)]
 pub struct Clamp<T, Source, const DIM: usize>
 where
     Source: NoiseFn<T, DIM>,

--- a/src/noise_fns/modifiers/curve.rs
+++ b/src/noise_fns/modifiers/curve.rs
@@ -16,6 +16,7 @@ use core::marker::PhantomData;
 /// four control points to the curve. If there is less than four control
 /// points, the get() method panics. Each control point can have any input
 /// and output value, although no two control points can have the same input.
+#[derive(Clone)]
 pub struct Curve<T, Source, const DIM: usize>
 where
     Source: NoiseFn<T, DIM>,
@@ -29,6 +30,7 @@ where
     phantom: PhantomData<T>,
 }
 
+#[derive(Clone)]
 struct ControlPoint<T> {
     input: T,
     output: T,

--- a/src/noise_fns/modifiers/exponent.rs
+++ b/src/noise_fns/modifiers/exponent.rs
@@ -8,6 +8,7 @@ use core::marker::PhantomData;
 /// this noise function first normalizes the output value (the range becomes 0.0
 /// to 1.0), maps that value onto an exponential curve, then rescales that
 /// value back to the original range.
+#[derive(Clone)]
 pub struct Exponent<T, Source, const DIM: usize>
 where
     Source: NoiseFn<T, DIM>,

--- a/src/noise_fns/modifiers/negate.rs
+++ b/src/noise_fns/modifiers/negate.rs
@@ -2,6 +2,7 @@ use crate::noise_fns::NoiseFn;
 use core::marker::PhantomData;
 
 /// Noise function that negates the output value from the source function.
+#[derive(Clone)]
 pub struct Negate<T, Source, const DIM: usize>
 where
     Source: NoiseFn<T, DIM>,

--- a/src/noise_fns/modifiers/scale_bias.rs
+++ b/src/noise_fns/modifiers/scale_bias.rs
@@ -6,6 +6,7 @@ use core::marker::PhantomData;
 ///
 /// The function retrieves the output value from the source function, multiplies
 /// it with the scaling factor, adds the bias to it, then outputs the value.
+#[derive(Clone)]
 pub struct ScaleBias<T, Source, const DIM: usize> {
     /// Outputs a value.
     pub source: Source,

--- a/src/noise_fns/modifiers/terrace.rs
+++ b/src/noise_fns/modifiers/terrace.rs
@@ -25,6 +25,7 @@ use core::marker::PhantomData;
 ///
 /// This noise function is often used to generate terrain features such as the
 /// stereotypical desert canyon.
+#[derive(Clone)]
 pub struct Terrace<T, Source, const DIM: usize>
 where
     Source: NoiseFn<T, DIM>,

--- a/src/noise_fns/selectors/blend.rs
+++ b/src/noise_fns/selectors/blend.rs
@@ -6,6 +6,7 @@ use core::marker::PhantomData;
 ///
 /// This noise function uses linear interpolation to perform the blending
 /// operation.
+#[derive(Clone)]
 pub struct Blend<T, Source1, Source2, Control, const DIM: usize>
 where
     Source1: NoiseFn<T, DIM>,

--- a/src/noise_fns/selectors/select.rs
+++ b/src/noise_fns/selectors/select.rs
@@ -6,6 +6,7 @@ use core::marker::PhantomData;
 
 /// Noise function that outputs the value selected from one of two source
 /// functions chosen by the output value from a control function.
+#[derive(Clone)]
 pub struct Select<T, Source1, Source2, Control, const DIM: usize>
 where
     Source1: NoiseFn<T, DIM>,

--- a/src/noise_fns/transformers/displace.rs
+++ b/src/noise_fns/transformers/displace.rs
@@ -2,6 +2,7 @@ use crate::noise_fns::NoiseFn;
 
 /// Noise function that uses multiple source functions to displace each coordinate
 /// of the input value before returning the output value from the `source` function.
+#[derive(Clone)]
 pub struct Displace<Source, XDisplace, YDisplace, ZDisplace, UDisplace> {
     /// Source function that outputs a value
     pub source: Source,

--- a/src/noise_fns/transformers/rotate_point.rs
+++ b/src/noise_fns/transformers/rotate_point.rs
@@ -8,6 +8,7 @@ use crate::noise_fns::NoiseFn;
 ///
 /// The coordinate system of the input value is assumed to be "right-handed"
 /// (_x_ increases to the right, _y_ increases upward, and _z_ increases inward).
+#[derive(Clone)]
 pub struct RotatePoint<Source> {
     /// Source function that outputs a value
     pub source: Source,

--- a/src/noise_fns/transformers/scale_point.rs
+++ b/src/noise_fns/transformers/scale_point.rs
@@ -5,6 +5,7 @@ use crate::noise_fns::NoiseFn;
 ///
 /// The get() method multiplies the coordinates of the input value with a
 /// scaling factor before returning the output value from the source function.
+#[derive(Clone)]
 pub struct ScalePoint<Source> {
     /// Source function that outputs a value
     pub source: Source,

--- a/src/noise_fns/transformers/translate_point.rs
+++ b/src/noise_fns/transformers/translate_point.rs
@@ -5,6 +5,7 @@ use crate::noise_fns::NoiseFn;
 ///
 /// The get() method moves the coordinates of the input value by a translation
 /// amount before returning the output value from the source function.
+#[derive(Clone)]
 pub struct TranslatePoint<Source> {
     /// Source function that outputs a value
     pub source: Source,


### PR DESCRIPTION
Not sure if this is intentional. But I was trying to create a wrapper for some of the noise functions and operators. I wanted to impl `Clone`, but wasn't able to, because some functions weren't implementing `Clone`.
