### PR TITLE
Add spheres to core functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -213,3 +213,7 @@ required-features = ["images"]
 [[example]]
 name = "simplex"
 required-features = ["images"]
+
+[[example]]
+name = "spheres"
+required-features = ["images"]

--- a/examples/cylinders.rs
+++ b/examples/cylinders.rs
@@ -9,6 +9,7 @@ fn main() {
         &PlaneMapBuilder::new(Cylinders::new()).build(),
         "cylinders.png",
     );
+
     utils::write_example_to_file(
         &PlaneMapBuilder::new(Cylinders::new().set_frequency(5.0)).build(),
         "cylinders-f5.png",

--- a/examples/spheres.rs
+++ b/examples/spheres.rs
@@ -1,0 +1,34 @@
+extern crate noise;
+
+use noise::{core::spheres::*, utils::*};
+
+mod utils;
+
+fn main() {
+    utils::write_example_to_file(
+        &PlaneMapBuilder::new_fn(|point| spheres_2d(point.into(), 1.0))
+            .set_size(1024, 1024)
+            .set_x_bounds(-5.0, 5.0)
+            .set_y_bounds(-5.0, 5.0)
+            .build(),
+        "spheres 2d.png",
+    );
+
+    utils::write_example_to_file(
+        &PlaneMapBuilder::new_fn(|point| spheres_3d(point.into(), 2.0))
+            .set_size(1024, 1024)
+            .set_x_bounds(-5.0, 5.0)
+            .set_y_bounds(-5.0, 5.0)
+            .build(),
+        "spheres 3d.png",
+    );
+
+    utils::write_example_to_file(
+        &PlaneMapBuilder::new_fn(|point| spheres_4d(point.into(), 3.0))
+            .set_size(1024, 1024)
+            .set_x_bounds(-5.0, 5.0)
+            .set_y_bounds(-5.0, 5.0)
+            .build(),
+        "spheres 4d.png",
+    );
+}

--- a/src/core.rs
+++ b/src/core.rs
@@ -3,6 +3,7 @@ pub mod open_simplex;
 pub mod perlin;
 pub mod perlin_surflet;
 pub mod simplex;
+pub mod spheres;
 pub mod super_simplex;
 pub mod value;
 pub mod worley;

--- a/src/core/spheres.rs
+++ b/src/core/spheres.rs
@@ -1,0 +1,22 @@
+use crate::math::vectors::{Vector2, Vector3, Vector4};
+
+macro_rules! impl_sphere {
+    ($name:ident, $vector:ty) => {
+        #[inline(always)]
+        pub fn $name(point: $vector, frequency: f64) -> f64 {
+            let point = point * frequency;
+
+            let dist_from_center = point.magnitude();
+
+            let dist_from_smaller_sphere = dist_from_center - dist_from_center.floor();
+            let dist_from_larger_sphere = 1.0 - dist_from_smaller_sphere;
+            let nearest_dist = dist_from_smaller_sphere.min(dist_from_larger_sphere);
+
+            1.0 - (nearest_dist * 4.0)
+        }
+    };
+}
+
+impl_sphere!(spheres_2d, Vector2<f64>);
+impl_sphere!(spheres_3d, Vector3<f64>);
+impl_sphere!(spheres_4d, Vector4<f64>);

--- a/src/noise_fns/generators/cylinders.rs
+++ b/src/noise_fns/generators/cylinders.rs
@@ -1,4 +1,4 @@
-use crate::noise_fns::NoiseFn;
+use crate::{core::spheres::*, math::vectors::Vector2, noise_fns::NoiseFn};
 
 /// Noise function that outputs concentric cylinders.
 ///
@@ -31,20 +31,20 @@ impl Default for Cylinders {
     }
 }
 
-impl<const N: usize> NoiseFn<f64, N> for Cylinders {
-    fn get(&self, point: [f64; N]) -> f64 {
-        // Scale the inputs by the frequency.
-        let x = point[0] * self.frequency;
-        let y = point[1] * self.frequency;
+impl NoiseFn<f64, 2> for Cylinders {
+    fn get(&self, point: [f64; 2]) -> f64 {
+        spheres_2d(point.into(), self.frequency)
+    }
+}
 
-        // Calculate the distance of the point from the origin.
-        let dist_from_center = (x.powi(2) + y.powi(2)).sqrt();
+impl NoiseFn<f64, 3> for Cylinders {
+    fn get(&self, point: [f64; 3]) -> f64 {
+        spheres_2d(Vector2::new(point[0], point[1]), self.frequency)
+    }
+}
 
-        let dist_from_smaller_sphere = dist_from_center - dist_from_center.floor();
-        let dist_from_larger_sphere = 1.0 - dist_from_smaller_sphere;
-        let nearest_dist = dist_from_smaller_sphere.min(dist_from_larger_sphere);
-
-        // Shift the result to be in the -1.0 to +1.0 range.
-        1.0 - (nearest_dist * 4.0)
+impl NoiseFn<f64, 4> for Cylinders {
+    fn get(&self, point: [f64; 4]) -> f64 {
+        spheres_2d(Vector2::new(point[0], point[1]), self.frequency)
     }
 }


### PR DESCRIPTION
Spheres will output a series of concentric spheres, as a triangle graph between 0 and 1, at the specified frequency. It has 2D, 3D and 4D versions.

The cylinders generator was updated to call the spheres functions. It always calls the 2D version, because the 2D version is equivalent to what cylinders is already built to do. Spheres is a generalization of that to higher dimensions.

Also fixed the cylinders example.
