### PR TITLE
Update Perlin Surflet

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,10 @@ name = "perlin"
 harness = false
 
 [[bench]]
+name = "perlin_surflet"
+harness = false
+
+[[bench]]
 name = "simplex"
 harness = false
 

--- a/benches/perlin_surflet.rs
+++ b/benches/perlin_surflet.rs
@@ -1,0 +1,95 @@
+#[macro_use]
+extern crate criterion;
+extern crate noise;
+
+use criterion::{black_box, Criterion};
+use noise::{
+    core::perlin_surflet::{perlin_surflet_2d, perlin_surflet_3d, perlin_surflet_4d},
+    math::vectors::{Vector2, Vector3, Vector4},
+    permutationtable::PermutationTable,
+};
+
+criterion_group!(
+    perlin_surflet,
+    bench_perlin_surflet2,
+    bench_perlin_surflet3,
+    bench_perlin_surflet4
+);
+criterion_group!(
+    perlin_surflet_64x64,
+    bench_perlin_surflet2_64x64,
+    bench_perlin_surflet3_64x64,
+    bench_perlin_surflet4_64x64
+);
+criterion_main!(perlin_surflet, perlin_surflet_64x64);
+
+fn bench_perlin_surflet2(c: &mut Criterion) {
+    let hasher = PermutationTable::new(0);
+    c.bench_function("perlin surflet 2d", |b| {
+        b.iter(|| perlin_surflet_2d(black_box(Vector2::new(42.0_f64, 37.0)), &hasher))
+    });
+}
+
+fn bench_perlin_surflet3(c: &mut Criterion) {
+    let hasher = PermutationTable::new(0);
+    c.bench_function("perlin surflet 3d", |b| {
+        b.iter(|| perlin_surflet_3d(black_box(Vector3::new(42.0_f64, 37.0, 26.0)), &hasher))
+    });
+}
+
+fn bench_perlin_surflet4(c: &mut Criterion) {
+    let hasher = PermutationTable::new(0);
+    c.bench_function("perlin surflet 4d", |b| {
+        b.iter(|| {
+            perlin_surflet_4d(
+                black_box(Vector4::new(42.0_f64, 37.0, 26.0, 128.0)),
+                &hasher,
+            )
+        })
+    });
+}
+
+fn bench_perlin_surflet2_64x64(c: &mut Criterion) {
+    let hasher = PermutationTable::new(0);
+    c.bench_function("perlin surflet 2d (64x64)", |b| {
+        b.iter(|| {
+            for y in 0i8..64 {
+                for x in 0i8..64 {
+                    perlin_surflet_2d(black_box(Vector2::new(x as f64, y as f64)), &hasher);
+                }
+            }
+        })
+    });
+}
+
+fn bench_perlin_surflet3_64x64(c: &mut Criterion) {
+    let hasher = PermutationTable::new(0);
+    c.bench_function("perlin surflet 3d (64x64)", |b| {
+        b.iter(|| {
+            for y in 0i8..64 {
+                for x in 0i8..64 {
+                    perlin_surflet_3d(
+                        black_box(Vector3::new(x as f64, y as f64, x as f64)),
+                        &hasher,
+                    );
+                }
+            }
+        })
+    });
+}
+
+fn bench_perlin_surflet4_64x64(c: &mut Criterion) {
+    let hasher = PermutationTable::new(0);
+    c.bench_function("perlin surflet 4d (64x64)", |b| {
+        b.iter(|| {
+            for y in 0i8..64 {
+                for x in 0i8..64 {
+                    perlin_surflet_4d(
+                        black_box(Vector4::new(x as f64, y as f64, x as f64, y as f64)),
+                        &hasher,
+                    );
+                }
+            }
+        })
+    });
+}

--- a/examples/perlin_surflet.rs
+++ b/examples/perlin_surflet.rs
@@ -1,31 +1,42 @@
-//! An example of using perlin noise
+//! An example of using perlin_surflet noise
 
 extern crate noise;
 
-use noise::{utils::*, PerlinSurflet, Seedable};
+use noise::{
+    core::perlin_surflet::{perlin_surflet_2d, perlin_surflet_3d, perlin_surflet_4d},
+    permutationtable::PermutationTable,
+    utils::*,
+};
 
 mod utils;
 
 fn main() {
-    let perlin = PerlinSurflet::default();
+    let hasher = PermutationTable::new(0);
 
     utils::write_example_to_file(
-        &PlaneMapBuilder::new(perlin)
+        &PlaneMapBuilder::new_fn(|point| perlin_surflet_2d(point.into(), &hasher))
             .set_size(1024, 1024)
             .set_x_bounds(-5.0, 5.0)
             .set_y_bounds(-5.0, 5.0)
             .build(),
-        "perlin_surflet.png",
+        "perlin surflet 2d.png",
     );
 
-    let perlin = perlin.set_seed(1);
-
     utils::write_example_to_file(
-        &PlaneMapBuilder::new(perlin)
+        &PlaneMapBuilder::new_fn(|point| perlin_surflet_3d(point.into(), &hasher))
             .set_size(1024, 1024)
             .set_x_bounds(-5.0, 5.0)
             .set_y_bounds(-5.0, 5.0)
             .build(),
-        "perlin_surflet_seed=1.png",
+        "perlin surflet 3d.png",
+    );
+
+    utils::write_example_to_file(
+        &PlaneMapBuilder::new_fn(|point| perlin_surflet_4d(point.into(), &hasher))
+            .set_size(1024, 1024)
+            .set_x_bounds(-5.0, 5.0)
+            .set_y_bounds(-5.0, 5.0)
+            .build(),
+        "perlin surflet 4d.png",
     );
 }

--- a/src/core/perlin_surflet.rs
+++ b/src/core/perlin_surflet.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 
 #[inline(always)]
-pub fn perlin_surflet_2d<NH>(point: [f64; 2], hasher: &NH) -> f64
+pub fn perlin_surflet_2d<NH>(point: Vector2<f64>, hasher: &NH) -> f64
 where
     NH: NoiseHasher + ?Sized,
 {
@@ -21,8 +21,6 @@ where
             0.0
         }
     }
-
-    let point = Vector2::from(point);
 
     let corner = point.floor_to_isize();
     let floored = corner.numcast().unwrap();
@@ -47,7 +45,8 @@ where
     ((f00 + f10 + f01 + f11) * SCALE_FACTOR).clamp(-1.0, 1.0)
 }
 
-pub fn perlin_surflet_3d<NH>(point: [f64; 3], hasher: &NH) -> f64
+#[inline(always)]
+pub fn perlin_surflet_3d<NH>(point: Vector3<f64>, hasher: &NH) -> f64
 where
     NH: NoiseHasher + ?Sized,
 {
@@ -64,8 +63,6 @@ where
             0.0
         }
     }
-
-    let point = Vector3::from(point);
 
     let corner = point.floor_to_isize();
     let floored = corner.numcast().unwrap();
@@ -94,7 +91,8 @@ where
     ((f000 + f100 + f010 + f110 + f001 + f101 + f011 + f111) * SCALE_FACTOR).clamp(-1.0, 1.0)
 }
 
-pub fn perlin_surflet_4d<NH>(point: [f64; 4], hasher: &NH) -> f64
+#[inline(always)]
+pub fn perlin_surflet_4d<NH>(point: Vector4<f64>, hasher: &NH) -> f64
 where
     NH: NoiseHasher + ?Sized,
 {
@@ -111,8 +109,6 @@ where
             0.0
         }
     }
-
-    let point = Vector4::from(point);
 
     let corner = point.floor_to_isize();
     let floored = corner.numcast().unwrap();

--- a/src/noise_fns/generators/perlin_surflet.rs
+++ b/src/noise_fns/generators/perlin_surflet.rs
@@ -54,20 +54,20 @@ impl Seedable for PerlinSurflet {
 /// 2-dimensional perlin noise
 impl NoiseFn<f64, 2> for PerlinSurflet {
     fn get(&self, point: [f64; 2]) -> f64 {
-        perlin_surflet_2d(point, &self.perm_table)
+        perlin_surflet_2d(point.into(), &self.perm_table)
     }
 }
 
 /// 3-dimensional perlin noise
 impl NoiseFn<f64, 3> for PerlinSurflet {
     fn get(&self, point: [f64; 3]) -> f64 {
-        perlin_surflet_3d(point, &self.perm_table)
+        perlin_surflet_3d(point.into(), &self.perm_table)
     }
 }
 
 /// 4-dimensional perlin noise
 impl NoiseFn<f64, 4> for PerlinSurflet {
     fn get(&self, point: [f64; 4]) -> f64 {
-        perlin_surflet_4d(point, &self.perm_table)
+        perlin_surflet_4d(point.into(), &self.perm_table)
     }
 }


### PR DESCRIPTION
Perlin surflet noise didn't previously have benches. They now do. Also updated the examples to output 2D, 3D and 4D images.

The perlin surflet core functions now take a Vector2/3/4 as it's input,instead of taking an array and converting.
