### PR TITLE
Use Path instead of String for filenames when generating images

### DIFF
--- a/examples/utils.rs
+++ b/examples/utils.rs
@@ -11,7 +11,7 @@ pub fn write_example_to_file(map: &NoiseMap, filename: &str) {
     fs::create_dir_all(target.clone().parent().expect("No parent directory found."))
         .expect("Failed to create directories.");
 
-    map.write_to_file(target.to_str().unwrap())
+    map.write_to_file(&target)
 }
 
 #[allow(dead_code)]
@@ -24,7 +24,7 @@ pub fn write_image_to_file(image: &NoiseImage, filename: &str) {
     fs::create_dir_all(target.clone().parent().expect("No parent directory found."))
         .expect("Failed to create directories.");
 
-    image.write_to_file(target.to_str().unwrap())
+    image.write_to_file(&target)
 }
 
 #[allow(dead_code)]

--- a/examples/utils.rs
+++ b/examples/utils.rs
@@ -6,13 +6,10 @@ use noise::utils::{NoiseImage, NoiseMap};
 pub fn write_example_to_file(map: &NoiseMap, filename: &str) {
     use std::{fs, path::Path};
 
-    let target_dir = Path::new("example_images/");
+    let target = Path::new("example_images/").join(Path::new(filename));
 
-    if !target_dir.exists() {
-        fs::create_dir(target_dir).expect("failed to create example_images directory");
-    }
-
-    let target = target_dir.join(Path::new(filename));
+    fs::create_dir_all(target.clone().parent().expect("No parent directory found."))
+        .expect("Failed to create directories.");
 
     map.write_to_file(target.to_str().unwrap())
 }
@@ -22,13 +19,10 @@ pub fn write_example_to_file(map: &NoiseMap, filename: &str) {
 pub fn write_image_to_file(image: &NoiseImage, filename: &str) {
     use std::{fs, path::Path};
 
-    let target_dir = Path::new("example_images/");
+    let target = Path::new("example_images/").join(Path::new(filename));
 
-    if !target_dir.exists() {
-        fs::create_dir(target_dir).expect("failed to create example_images directory");
-    }
-
-    let target = target_dir.join(Path::new(filename));
+    fs::create_dir_all(target.clone().parent().expect("No parent directory found."))
+        .expect("Failed to create directories.");
 
     image.write_to_file(target.to_str().unwrap())
 }

--- a/src/utils/noise_image.rs
+++ b/src/utils/noise_image.rs
@@ -4,6 +4,8 @@ use alloc::{
     vec::{IntoIter, Vec},
 };
 use core::ops::{Index, IndexMut};
+#[cfg(feature = "images")]
+use std::path::Path;
 
 const RASTER_MAX_WIDTH: u16 = 32_767;
 const RASTER_MAX_HEIGHT: u16 = 32_767;
@@ -101,9 +103,7 @@ impl NoiseImage {
     }
 
     #[cfg(feature = "images")]
-    pub fn write_to_file(&self, filename: &str) {
-        use std::path::Path;
-
+    pub fn write_to_file(&self, filename: &Path) {
         // collect the values from the map vector into an array
         let (width, height) = self.size;
         let mut result = Vec::with_capacity(width * height);
@@ -115,14 +115,14 @@ impl NoiseImage {
         }
 
         let _ = image::save_buffer(
-            &Path::new(filename),
+            filename,
             &*result,
             self.size.0 as u32,
             self.size.1 as u32,
             image::ColorType::Rgba8,
         );
 
-        println!("\nFinished generating {}", filename);
+        println!("\nFinished generating {}", filename.to_string_lossy());
     }
 }
 

--- a/src/utils/noise_image.rs
+++ b/src/utils/noise_image.rs
@@ -116,7 +116,7 @@ impl NoiseImage {
 
         let _ = image::save_buffer(
             filename,
-            &*result,
+            &result,
             self.size.0 as u32,
             self.size.1 as u32,
             image::ColorType::Rgba8,

--- a/src/utils/noise_map.rs
+++ b/src/utils/noise_map.rs
@@ -105,7 +105,7 @@ impl NoiseMap {
 
         let _ = image::save_buffer(
             filename,
-            &*pixels,
+            &pixels,
             self.size.0 as u32,
             self.size.1 as u32,
             image::ColorType::L8,

--- a/src/utils/noise_map.rs
+++ b/src/utils/noise_map.rs
@@ -3,6 +3,8 @@ use alloc::{
     vec::{IntoIter, Vec},
 };
 use core::ops::{Index, IndexMut};
+#[cfg(feature = "images")]
+use std::path::Path;
 
 const RASTER_MAX_WIDTH: u16 = 32_767;
 const RASTER_MAX_HEIGHT: u16 = 32_767;
@@ -92,9 +94,7 @@ impl NoiseMap {
     }
 
     #[cfg(feature = "images")]
-    pub fn write_to_file(&self, filename: &str) {
-        use std::path::Path;
-
+    pub fn write_to_file(&self, filename: &Path) {
         // collect the values from f64 into u8 in a separate vec
         let (width, height) = self.size;
         let mut pixels: Vec<u8> = Vec::with_capacity(width * height);
@@ -104,14 +104,14 @@ impl NoiseMap {
         }
 
         let _ = image::save_buffer(
-            &Path::new(&filename),
+            filename,
             &*pixels,
             self.size.0 as u32,
             self.size.1 as u32,
             image::ColorType::L8,
         );
 
-        println!("\nFinished generating {}", filename);
+        println!("\nFinished generating {}", filename.to_string_lossy());
     }
 
     fn initialize() -> Self {


### PR DESCRIPTION
Filename starts as path, gets converted to string, then converted back to path. This eliminates the string conversion stage.