### PR TITLE
Add `Debug` auto-derivations to `noise_fn`s

### DIFF
--- a/src/noise_fns/combiners/add.rs
+++ b/src/noise_fns/combiners/add.rs
@@ -3,7 +3,7 @@ use core::marker::PhantomData;
 
 /// Noise function that outputs the sum of the two output values from two source
 /// functions.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Add<T, Source1, Source2, const DIM: usize>
 where
     Source1: NoiseFn<T, DIM>,

--- a/src/noise_fns/combiners/max.rs
+++ b/src/noise_fns/combiners/max.rs
@@ -3,7 +3,7 @@ use core::marker::PhantomData;
 
 /// Noise function that outputs the larger of the two output values from two source
 /// functions.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Max<T, Source1, Source2, const DIM: usize>
 where
     Source1: NoiseFn<T, DIM>,

--- a/src/noise_fns/combiners/min.rs
+++ b/src/noise_fns/combiners/min.rs
@@ -3,7 +3,7 @@ use core::marker::PhantomData;
 
 /// Noise function that outputs the smaller of the two output values from two source
 /// functions.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Min<T, Source1, Source2, const DIM: usize>
 where
     Source1: NoiseFn<T, DIM>,

--- a/src/noise_fns/combiners/multiply.rs
+++ b/src/noise_fns/combiners/multiply.rs
@@ -3,7 +3,7 @@ use core::marker::PhantomData;
 
 /// Noise function that outputs the product of the two output values from two source
 /// functions.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Multiply<T, Source1, Source2, const DIM: usize>
 where
     Source1: NoiseFn<T, DIM>,

--- a/src/noise_fns/combiners/power.rs
+++ b/src/noise_fns/combiners/power.rs
@@ -3,7 +3,7 @@ use core::marker::PhantomData;
 
 /// Noise function that raises the output value from the first source function
 /// to the power of the output value of the second source function.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Power<T, Source1, Source2, const DIM: usize>
 where
     Source1: NoiseFn<T, DIM>,

--- a/src/noise_fns/modifiers/abs.rs
+++ b/src/noise_fns/modifiers/abs.rs
@@ -3,7 +3,7 @@ use core::marker::PhantomData;
 
 /// Noise function that outputs the absolute value of the output value from the
 /// source function.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Abs<T, Source, const DIM: usize>
 where
     Source: NoiseFn<T, DIM>,

--- a/src/noise_fns/modifiers/clamp.rs
+++ b/src/noise_fns/modifiers/clamp.rs
@@ -3,7 +3,7 @@ use core::marker::PhantomData;
 
 /// Noise function that clamps the output value from the source function to a
 /// range of values.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Clamp<T, Source, const DIM: usize>
 where
     Source: NoiseFn<T, DIM>,

--- a/src/noise_fns/modifiers/curve.rs
+++ b/src/noise_fns/modifiers/curve.rs
@@ -16,7 +16,7 @@ use core::marker::PhantomData;
 /// four control points to the curve. If there is less than four control
 /// points, the get() method panics. Each control point can have any input
 /// and output value, although no two control points can have the same input.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Curve<T, Source, const DIM: usize>
 where
     Source: NoiseFn<T, DIM>,
@@ -30,7 +30,7 @@ where
     phantom: PhantomData<T>,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 struct ControlPoint<T> {
     input: T,
     output: T,

--- a/src/noise_fns/modifiers/exponent.rs
+++ b/src/noise_fns/modifiers/exponent.rs
@@ -8,7 +8,7 @@ use core::marker::PhantomData;
 /// this noise function first normalizes the output value (the range becomes 0.0
 /// to 1.0), maps that value onto an exponential curve, then rescales that
 /// value back to the original range.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Exponent<T, Source, const DIM: usize>
 where
     Source: NoiseFn<T, DIM>,

--- a/src/noise_fns/modifiers/negate.rs
+++ b/src/noise_fns/modifiers/negate.rs
@@ -2,7 +2,7 @@ use crate::noise_fns::NoiseFn;
 use core::marker::PhantomData;
 
 /// Noise function that negates the output value from the source function.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Negate<T, Source, const DIM: usize>
 where
     Source: NoiseFn<T, DIM>,

--- a/src/noise_fns/modifiers/scale_bias.rs
+++ b/src/noise_fns/modifiers/scale_bias.rs
@@ -6,7 +6,7 @@ use core::marker::PhantomData;
 ///
 /// The function retrieves the output value from the source function, multiplies
 /// it with the scaling factor, adds the bias to it, then outputs the value.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct ScaleBias<T, Source, const DIM: usize> {
     /// Outputs a value.
     pub source: Source,

--- a/src/noise_fns/modifiers/terrace.rs
+++ b/src/noise_fns/modifiers/terrace.rs
@@ -25,7 +25,7 @@ use core::marker::PhantomData;
 ///
 /// This noise function is often used to generate terrain features such as the
 /// stereotypical desert canyon.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Terrace<T, Source, const DIM: usize>
 where
     Source: NoiseFn<T, DIM>,

--- a/src/noise_fns/selectors/blend.rs
+++ b/src/noise_fns/selectors/blend.rs
@@ -6,7 +6,7 @@ use core::marker::PhantomData;
 ///
 /// This noise function uses linear interpolation to perform the blending
 /// operation.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Blend<T, Source1, Source2, Control, const DIM: usize>
 where
     Source1: NoiseFn<T, DIM>,

--- a/src/noise_fns/selectors/select.rs
+++ b/src/noise_fns/selectors/select.rs
@@ -6,7 +6,7 @@ use core::marker::PhantomData;
 
 /// Noise function that outputs the value selected from one of two source
 /// functions chosen by the output value from a control function.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Select<T, Source1, Source2, Control, const DIM: usize>
 where
     Source1: NoiseFn<T, DIM>,


### PR DESCRIPTION
Except for Worley. Worley can't take auto-derive `Debug` due to the DistanceFunction.

Closes #348