### PR TITLE
Fix Negative Range of Perlin1D

### DIFF
--- a/benches/perlin.rs
+++ b/benches/perlin.rs
@@ -4,12 +4,18 @@ extern crate noise;
 
 use criterion::{black_box, Criterion};
 use noise::{
-    core::perlin::{perlin_2d, perlin_3d, perlin_4d},
+    core::perlin::{perlin_1d, perlin_2d, perlin_3d, perlin_4d},
     permutationtable::PermutationTable,
     Vector2, Vector3, Vector4,
 };
 
-criterion_group!(perlin, bench_perlin2, bench_perlin3, bench_perlin4);
+criterion_group!(
+    perlin,
+    bench_perlin1,
+    bench_perlin2,
+    bench_perlin3,
+    bench_perlin4
+);
 criterion_group!(
     perlin_64x64,
     bench_perlin2_64x64,
@@ -17,6 +23,13 @@ criterion_group!(
     bench_perlin4_64x64
 );
 criterion_main!(perlin, perlin_64x64);
+
+fn bench_perlin1(c: &mut Criterion) {
+    let hasher = PermutationTable::new(0);
+    c.bench_function("perlin 1d", |b| {
+        b.iter(|| perlin_1d(black_box(42.0_f64), &hasher))
+    });
+}
 
 fn bench_perlin2(c: &mut Criterion) {
     let hasher = PermutationTable::new(0);

--- a/src/core/perlin.rs
+++ b/src/core/perlin.rs
@@ -20,7 +20,7 @@ where
     // 1/(sqrt(N)/2), N=1 -> 2/sqrt(1) -> 2
     const SCALE_FACTOR: f64 = 2.0;
 
-    let corner = point as isize;
+    let corner = point.floor() as isize;
     let distance = point - corner as f64;
 
     macro_rules! call_gradient(


### PR DESCRIPTION
While making toy project, found out 1-dimensional Perlin noise was broken in negative range.

example:
```rs
#[test]
fn perlin_test() {
    let perlin = Perlin::new(69420);

    for i in -9..10 {
        let t = i as f64 / 10.0;
        let val = perlin.get([t]);
        println!("{:.2}: {:.2}", t, val);
    }
}
```

before fix:
```
-0.90: 1.00
-0.80: 1.00
-0.70: 1.00
-0.60: 1.00
-0.50: 1.00
-0.40: 0.80
-0.30: 0.60
-0.20: 0.40
-0.10: 0.20
0.00: -0.00
0.10: -0.21
0.20: -0.47
0.30: -0.73
0.40: -0.93
0.50: -1.00
0.60: -0.93
0.70: -0.73
0.80: -0.47
0.90: -0.2
```

after fix:
```
-0.90: 0.21
-0.80: 0.47
-0.70: 0.73
-0.60: 0.93
-0.50: 1.00
-0.40: 0.93
-0.30: 0.73
-0.20: 0.47
-0.10: 0.21
0.00: -0.00
0.10: -0.21
0.20: -0.47
0.30: -0.73
0.40: -0.93
0.50: -1.00
0.60: -0.93
0.70: -0.73
0.80: -0.47
0.90: -0.21
```

![perlin_test_stacked](https://github.com/Razaekel/noise-rs/assets/93528864/8873ddf3-cb43-4df9-9089-157a6f1c511e)
