### PR TITLE
Fix spelling on perlin_surflet.rs docs

### DIFF
--- a/src/noise_fns/generators/perlin_surflet.rs
+++ b/src/noise_fns/generators/perlin_surflet.rs
@@ -6,7 +6,7 @@ use crate::{
 
 /// Noise function that outputs 2/3/4-dimensional Perlin noise.
 ///
-/// THis is a variant of original perlin noise, based on the principles of simplex noise to
+/// This is a variant of original perlin noise, based on the principles of simplex noise to
 /// calculate the values at a point using wavelets instead of interpolated gradients.
 #[derive(Clone, Copy, Debug)]
 pub struct PerlinSurflet {


### PR DESCRIPTION
The description spelled "This" as "THis".