### PR TITLE
Add `libm` feature to allow `no_std` compilation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,12 +19,13 @@ name = "noise"
 rand = { version = "0.9", default-features = false }
 rand_xorshift = "0.4"
 image = { version = "0.25.5", optional = true }
-num-traits = "0.2"
+num-traits = { version = "0.2", default-features = false }
 
 [features]
-default = []
+default = ["std"]
 images = ["image", "std"]
-std = []
+std = ["num-traits/std"]
+libm = ["num-traits/libm"]
 
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["html_reports"] }

--- a/src/core/open_simplex.rs
+++ b/src/core/open_simplex.rs
@@ -1,3 +1,6 @@
+#[cfg(not(feature = "std"))]
+use num_traits::Float as _;
+
 use crate::{
     gradient,
     math::vectors::{Vector2, Vector3, Vector4},

--- a/src/core/perlin.rs
+++ b/src/core/perlin.rs
@@ -1,3 +1,6 @@
+#[cfg(not(feature = "std"))]
+use num_traits::Float as _;
+
 use crate::{
     math::{
         interpolate::linear,

--- a/src/core/perlin_surflet.rs
+++ b/src/core/perlin_surflet.rs
@@ -1,3 +1,6 @@
+#[cfg(not(feature = "std"))]
+use num_traits::Float as _;
+
 use crate::{
     gradient,
     math::vectors::{Vector2, Vector3, Vector4},

--- a/src/core/spheres.rs
+++ b/src/core/spheres.rs
@@ -1,3 +1,6 @@
+#[cfg(not(feature = "std"))]
+use num_traits::Float as _;
+
 use crate::math::vectors::{Vector2, Vector3, Vector4};
 
 macro_rules! impl_sphere {

--- a/src/core/super_simplex.rs
+++ b/src/core/super_simplex.rs
@@ -1,3 +1,6 @@
+#[cfg(not(feature = "std"))]
+use num_traits::Float as _;
+
 use crate::{gradient, math::vectors::*, permutationtable::NoiseHasher};
 
 const TO_REAL_CONSTANT_2D: f64 = -0.211_324_865_405_187; // (1 / sqrt(2 + 1) - 1) / 2

--- a/src/core/worley.rs
+++ b/src/core/worley.rs
@@ -1,3 +1,6 @@
+#[cfg(not(feature = "std"))]
+use num_traits::Float as _;
+
 use crate::{
     math::vectors::{Vector2, Vector3, Vector4},
     permutationtable::NoiseHasher,
@@ -11,6 +14,9 @@ pub enum ReturnType {
 }
 
 pub mod distance_functions {
+    #[cfg(not(feature = "std"))]
+    use num_traits::Float as _;
+
     pub fn euclidean(p1: &[f64], p2: &[f64]) -> f64 {
         p1.iter()
             .zip(p2)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,11 +9,14 @@
 //! let val = perlin.get([42.4, 37.7, 2.8]);
 //! ```
 
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 #![deny(missing_copy_implementations)]
 
 #[macro_use]
 extern crate alloc;
+
+#[cfg(feature = "std")]
+extern crate std;
 
 pub use crate::math::vectors::*;
 pub use crate::noise_fns::*;

--- a/src/math.rs
+++ b/src/math.rs
@@ -5,6 +5,9 @@ pub(crate) mod interpolate;
 pub(crate) mod s_curve;
 pub mod vectors;
 
+#[cfg(not(feature = "std"))]
+use num_traits::Float as _;
+
 #[cfg(not(target_os = "emscripten"))]
 #[inline]
 pub(crate) fn scale_shift(value: f64, n: f64) -> f64 {

--- a/src/noise_fns/combiners/power.rs
+++ b/src/noise_fns/combiners/power.rs
@@ -1,3 +1,6 @@
+#[cfg(not(feature = "std"))]
+use num_traits::Float as _;
+
 use crate::noise_fns::NoiseFn;
 use core::marker::PhantomData;
 

--- a/src/noise_fns/generators/fractals/basicmulti.rs
+++ b/src/noise_fns/generators/fractals/basicmulti.rs
@@ -1,3 +1,6 @@
+#[cfg(not(feature = "std"))]
+use num_traits::Float as _;
+
 use crate::{
     math::vectors::*,
     noise_fns::{MultiFractal, NoiseFn, Seedable},

--- a/src/noise_fns/generators/fractals/billow.rs
+++ b/src/noise_fns/generators/fractals/billow.rs
@@ -1,3 +1,6 @@
+#[cfg(not(feature = "std"))]
+use num_traits::Float as _;
+
 use crate::{
     math::{scale_shift, vectors::*},
     noise_fns::{MultiFractal, NoiseFn, Seedable},

--- a/src/noise_fns/generators/fractals/fbm.rs
+++ b/src/noise_fns/generators/fractals/fbm.rs
@@ -1,3 +1,6 @@
+#[cfg(not(feature = "std"))]
+use num_traits::Float as _;
+
 use crate::{
     math::vectors::*,
     noise_fns::{MultiFractal, NoiseFn, Seedable},

--- a/src/noise_fns/generators/fractals/ridgedmulti.rs
+++ b/src/noise_fns/generators/fractals/ridgedmulti.rs
@@ -1,3 +1,6 @@
+#[cfg(not(feature = "std"))]
+use num_traits::Float as _;
+
 use crate::{
     math::vectors::*,
     noise_fns::{MultiFractal, NoiseFn, Seedable},

--- a/src/noise_fns/modifiers/exponent.rs
+++ b/src/noise_fns/modifiers/exponent.rs
@@ -1,3 +1,6 @@
+#[cfg(not(feature = "std"))]
+use num_traits::Float as _;
+
 use crate::{math::scale_shift, noise_fns::NoiseFn};
 use core::marker::PhantomData;
 

--- a/src/noise_fns/modifiers/scale_bias.rs
+++ b/src/noise_fns/modifiers/scale_bias.rs
@@ -1,3 +1,6 @@
+#[cfg(not(feature = "std"))]
+use num_traits::Float as _;
+
 use crate::noise_fns::NoiseFn;
 use core::marker::PhantomData;
 

--- a/src/noise_fns/transformers/rotate_point.rs
+++ b/src/noise_fns/transformers/rotate_point.rs
@@ -1,3 +1,6 @@
+#[cfg(not(feature = "std"))]
+use num_traits::Float as _;
+
 use crate::noise_fns::NoiseFn;
 
 /// Noise function that rotates the input value around the origin before

--- a/src/utils/color_gradient.rs
+++ b/src/utils/color_gradient.rs
@@ -1,3 +1,6 @@
+#[cfg(not(feature = "std"))]
+use num_traits::Float as _;
+
 use alloc::vec::Vec;
 
 pub type Color = [u8; 4];

--- a/src/utils/noise_image.rs
+++ b/src/utils/noise_image.rs
@@ -122,7 +122,7 @@ impl NoiseImage {
             image::ColorType::Rgba8,
         );
 
-        println!("\nFinished generating {}", filename.to_string_lossy());
+        std::println!("\nFinished generating {}", filename.to_string_lossy());
     }
 }
 

--- a/src/utils/noise_map.rs
+++ b/src/utils/noise_map.rs
@@ -111,7 +111,7 @@ impl NoiseMap {
             image::ColorType::L8,
         );
 
-        println!("\nFinished generating {}", filename.to_string_lossy());
+        std::println!("\nFinished generating {}", filename.to_string_lossy());
     }
 
     fn initialize() -> Self {

--- a/src/utils/noise_map_builder/cylinder_map.rs
+++ b/src/utils/noise_map_builder/cylinder_map.rs
@@ -1,3 +1,6 @@
+#[cfg(not(feature = "std"))]
+use num_traits::Float as _;
+
 use crate::{utils::NoiseMap, NoiseFn};
 
 use super::NoiseMapBuilder;

--- a/src/utils/noise_map_builder/sphere_map.rs
+++ b/src/utils/noise_map_builder/sphere_map.rs
@@ -1,3 +1,6 @@
+#[cfg(not(feature = "std"))]
+use num_traits::Float as _;
+
 use crate::{utils::NoiseMap, NoiseFn};
 
 use super::NoiseMapBuilder;


### PR DESCRIPTION
# Objective

Currently, `no_std` targets such as `wasm32v1-none` fail to compile, as `num-traits` has its `std` feature permanently enabled. Additionally, without `std` linked, several important floating point methods are unavailable. This can be fixed by using `num-traits::Float` and enabling the `libm` feature.

## Solution

- Disable default features on `num-traits` to ensure `std` is not unconditionally enabled.
- Add a new `libm` feature which enables `num-traits/libm`
- Add `num-traits/std` to the `std` feature
- Enable `std` by default

---

## Notes

- No AI tooling of any kind was used during the creation of this PR.